### PR TITLE
feat: support allowed values label if comma separated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+ - New parameter `commaSeparatedValue` for the `labelHasAllowedValue` validator supporting labels with a comma separated values.
 
 ## [v1.1.0] - 2020-11-20
 ### Changed

--- a/docs/validations.md
+++ b/docs/validations.md
@@ -72,13 +72,15 @@ params:
 
 
 ### `labelHasAllowedValue`
-Fails if rule label value is not one of the allowed values.
+Fails if rule label value is not one of the allowed values. If the `commaSeparatedValue` is set to true, the label value
+to true, the label vaue is split by a comma, and the distinct values are check if valid.
 > It's quite common to have well known severities for alerts which can be important even in the
 > Alertmanager routing tree. Ths is how you can make sure only the well-known severities are used.
 ```yaml
 params:
   label: "foo"
   allowedValues: ["foo", "bar"]
+  commaSeparatedValue: true
 ```
 
 ### `annotationHasAllowedValue`

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -57,7 +57,9 @@ var testCases = []struct {
 
 	// labelHasAllowedValue
 	{name: "ruleHasLabelWithAllowedValue", validator: labelHasAllowedValue{label: "foo", allowedValues: []string{"bar"}}, rule: rulefmt.Rule{Labels: map[string]string{"foo": "bar"}}, expectedErrors: 0},
+	{name: "ruleHasCsvLabelWithAllowedValue", validator: labelHasAllowedValue{label: "foo", allowedValues: []string{"bar"}, commaSeparatedValue: true}, rule: rulefmt.Rule{Labels: map[string]string{"foo": "xxx,bar"}}, expectedErrors: 0},
 	{name: "ruleDoesNotHaveLabelWithAllowedValue", validator: labelHasAllowedValue{label: "foo", allowedValues: []string{"bar"}}, rule: rulefmt.Rule{Labels: map[string]string{"foo": "xxx"}}, expectedErrors: 1},
+	{name: "ruleHasCsvLabelWithoutAllowedValue", validator: labelHasAllowedValue{label: "foo", allowedValues: []string{"bar"}, commaSeparatedValue: true}, rule: rulefmt.Rule{Labels: map[string]string{"foo": "xxx,yyy"}}, expectedErrors: 1},
 
 	// annotationHasAllowedValue
 	{name: "ruleHasAnnotationWithAllowedValue", validator: annotationHasAllowedValue{annotation: "foo", allowedValues: []string{"bar"}}, rule: rulefmt.Rule{Annotations: map[string]string{"foo": "bar"}}, expectedErrors: 0},


### PR DESCRIPTION
Validation of allowed label values now supports splitting the label value by comma before. 

