### PR TITLE
feat: add support for comma separated values in annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+ - New parameter `commaSeparatedValue` for the `annotationHasAllowedValue` validator supporting annotations with a comma separated values.
 
 ## [v1.2.0] - 2020-11-29
 ### Added

--- a/docs/validations.md
+++ b/docs/validations.md
@@ -89,6 +89,7 @@ Fails if rule annotation value is not one of the allowed values.
 params:
   annotation: "foo"
   allowedValues: ["foo", "bar"]
+  commaSeparatedValue: true
 ```
 
 ### `annotationIsValidURL`

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -63,7 +63,9 @@ var testCases = []struct {
 
 	// annotationHasAllowedValue
 	{name: "ruleHasAnnotationWithAllowedValue", validator: annotationHasAllowedValue{annotation: "foo", allowedValues: []string{"bar"}}, rule: rulefmt.Rule{Annotations: map[string]string{"foo": "bar"}}, expectedErrors: 0},
+	{name: "ruleHasCsvAnnotationWithAllowedValue", validator: annotationHasAllowedValue{annotation: "foo", allowedValues: []string{"bar"}, commaSeparatedValue: true}, rule: rulefmt.Rule{Annotations: map[string]string{"foo": "xxx,bar"}}, expectedErrors: 0},
 	{name: "ruleDoesNotHaveAnnotationWithAllowedValue", validator: annotationHasAllowedValue{annotation: "foo", allowedValues: []string{"bar"}}, rule: rulefmt.Rule{Annotations: map[string]string{"foo": "xxx"}}, expectedErrors: 1},
+	{name: "ruleHasCsvAnnotationWithoutAllowedValue", validator: annotationHasAllowedValue{annotation: "foo", allowedValues: []string{"bar"}, commaSeparatedValue: true}, rule: rulefmt.Rule{Annotations: map[string]string{"foo": "xxx,yyy"}}, expectedErrors: 1},
 
 	// annotationIsValidURL
 	{name: "ruleHasAnnotationWithValidURLAnnotation", validator: annotationIsValidURL{annotation: "foo"}, rule: rulefmt.Rule{Annotations: map[string]string{"foo": "https://fusakla.cz"}}, expectedErrors: 0},


### PR DESCRIPTION
Resolves #5 

Adds the support cor comma separated values for annotations allowed values