### PR TITLE
feat: Allow disabling validations by comments inside the rule expresion.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Log progress
   - Fix e2e test
 
+- [#26](https://github.com/FUSAKLA/promruval/pull/26)
+  - Allow disabling validations in comments inside the `expr` of rules.
+    This is useful when you generate the prometheus rule files from a system
+    that doesn't support YAML comments, e.g. jsonnet.
 
 ## [v2.2.0] - 2022-06-07
 

--- a/README.md
+++ b/README.md
@@ -185,9 +185,11 @@ Therefore, it's recommended to use these check as a warning and do not fail if i
 
 ### Disabling validations per rule
 
-If you want to disable particular validator for a certain rule, you can add a comment in above it with a list of
-validator names to ignore in theis case.
-By default, the comment prefix is `ignore_validations` bud can be changed using the `customDisableComment` config option
+If you want to disable particular validation for a certain rule, you can add a comment above it with a list of
+validation names to ignore. Alternatively, the comment can be put on its own line _inside_ the `expr` of the rule.
+The in-expression comment can be present multiple times.
+
+By default, the comment prefix is `ignore_validations` but can be changed using the `customDisableComment` config option
 in [config](#configuration).
 Value of the comment should be comma separated list of [validation names](./docs/validations.md)
 
@@ -195,11 +197,19 @@ Example:
 
 ```yaml
 groups:
-  # ignore_validations: expressionSelectorsMatchesAnything, expressionDoesNotUseOlderDataThan
   - name: foo
     rules:
+      # The following validations will be ignored in the rule that immediately follows.
+      # ignore_validations: expressionSelectorsMatchesAnything, expressionDoesNotUseOlderDataThan
       - record: bar
         expr: 1
+      # The same validations are disabled for the following rule, but the comments are in the expression.
+      - name: baz
+        expr: |
+          # ignore_validations: expressionSelectorsMatchesAnything
+          up{
+            # ignore_validations: expressionDoesNotUseOlderDataThan
+          }
 ```
 
 ### Disabling rules

--- a/examples/rules/rules.yaml
+++ b/examples/rules/rules.yaml
@@ -10,7 +10,9 @@ groups:
 
   - name: testGroup
     rules:
-      # ignore_validations: expressionSelectorsMatchesAnything, expressionDoesNotUseOlderDataThan
+      # Comment before.
+      # Comment on the same line. ignore_validations: expressionSelectorsMatchesAnything, expressionDoesNotUseOlderDataThan
+      # Comment after.
       - alert: test
         expr: avg_over_time(max_over_time(up{job="prometheus"}[10h] offset 10d)[10m:10m])
         for: 4w
@@ -22,3 +24,18 @@ groups:
           title: test alert
           playbook: http://foo.bar/nonexisting/playbook
           disabled_validation_rules: check-team-label,check-prometheus-limitations
+
+  - name: testIgnoreValidationsInExpr
+    rules:
+      - alert: test
+        expr: |
+          # Comment before.
+          # Comment on the same line. ignore_validations: labelHasAllowedValue
+          # Comment after.
+          foo{
+            # ignore_validations: expressionSelectorsMatchesAnything, hasLabels
+          }
+        for: 1m
+        annotations:
+          title: test alert
+          playbook: http://foo.bar/nonexisting/playbook


### PR DESCRIPTION
We are generating some of our Prometheus rules by [jsonnet](https://jsonnet.org/), which outputs JSON, making it impossible to generate the `disable_validations` comment for a particular rule.

This PR allows using the comment _inside_ the rules' `expr` as long as it is on its own line within the expression. See the [Prometheus docs](https://prometheus.io/docs/prometheus/latest/querying/basics/#comments).

I also fixed a little bugs in the handling of the YAML comment: It is now possible to have comment lines that follow the `disable_validations` line.

Plus a few typos in the README.
