### PR TITLE
Fus fix interval params validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fixed param validation of the `hasAllowedEvaluationInterval` validator, if the `maximum` was not set.
 
 ## [v2.8.0] - 2024-02-29
 - Added new param `ignoreTemplatedValues` to the `labelHasAllowedValue` validator to ignore templated values in the label.

--- a/examples/human_readable.html
+++ b/examples/human_readable.html
@@ -48,7 +48,7 @@
   <h2><a href="#check-groups">check-groups</a></h2>
 	  <ul>
 		<li>Group does not have other <code>source_tenants</code> than: <code>tenant1</code>, <code>tenant2</code>, <code>k8s</code></li>
-		<li>Group evaluation interval is between <code>20s</code> and <code>10m0s</code> if set</li>
+		<li>Group evaluation interval is between <code>20s</code> and <code>2562047h47m16.854775807s</code> if set</li>
 		<li>Group has valid partial_response_strategy (one of <code>warn</code> or <code>abort</code>) if set</li>
 	  </ul>
 

--- a/examples/human_readable.html
+++ b/examples/human_readable.html
@@ -48,7 +48,7 @@
   <h2><a href="#check-groups">check-groups</a></h2>
 	  <ul>
 		<li>Group does not have other <code>source_tenants</code> than: <code>tenant1</code>, <code>tenant2</code>, <code>k8s</code></li>
-		<li>Group evaluation interval is between <code>20s</code> and <code>2562047h47m16.854775807s</code> if set</li>
+		<li>Group evaluation interval is between <code>20s</code> and <code>106751d23h47m16s854ms</code> if set</li>
 		<li>Group has valid partial_response_strategy (one of <code>warn</code> or <code>abort</code>) if set</li>
 	  </ul>
 

--- a/examples/human_readable.md
+++ b/examples/human_readable.md
@@ -33,7 +33,7 @@ Validation rules:
 
   check-groups
     - Group does not have other `source_tenants` than: `tenant1`, `tenant2`, `k8s`
-    - Group evaluation interval is between `20s` and `10m0s` if set
+    - Group evaluation interval is between `20s` and `2562047h47m16.854775807s` if set
     - Group has valid partial_response_strategy (one of `warn` or `abort`) if set
 
   another-checks

--- a/examples/human_readable.md
+++ b/examples/human_readable.md
@@ -33,7 +33,7 @@ Validation rules:
 
   check-groups
     - Group does not have other `source_tenants` than: `tenant1`, `tenant2`, `k8s`
-    - Group evaluation interval is between `20s` and `2562047h47m16.854775807s` if set
+    - Group evaluation interval is between `20s` and `106751d23h47m16s854ms` if set
     - Group has valid partial_response_strategy (one of `warn` or `abort`) if set
 
   another-checks

--- a/examples/validation.yaml
+++ b/examples/validation.yaml
@@ -93,6 +93,5 @@ validationRules:
       - type: hasAllowedEvaluationInterval
         params:
           minimum: "20s"
-          maximum: "10m"
           intervalMustBeSet: false
       - type: hasValidPartialStrategy

--- a/pkg/validator/group.go
+++ b/pkg/validator/group.go
@@ -52,15 +52,14 @@ func newHasAllowedEvaluationInterval(paramsConfig yaml.Node) (Validator, error) 
 	if err := paramsConfig.Decode(&params); err != nil {
 		return nil, err
 	}
+	if params.MaximumEvaluationInterval == 0 {
+		params.MaximumEvaluationInterval = time.Duration(1<<63 - 1)
+	}
 	if params.MinimumEvaluationInterval > params.MaximumEvaluationInterval {
 		return nil, fmt.Errorf("minimum is greater than maximum")
 	}
 	if params.MaximumEvaluationInterval == 0 && params.MinimumEvaluationInterval == 0 {
 		return nil, fmt.Errorf("at least one of the `minimum` or `maximum` must be set")
-	}
-	if params.MaximumEvaluationInterval == 0 {
-		params.MaximumEvaluationInterval = time.Duration(1<<63 - 1)
-
 	}
 	return &hasAllowedEvaluationInterval{minimum: params.MinimumEvaluationInterval, maximum: params.MaximumEvaluationInterval, mustBeSet: params.MustBeSet}, nil
 }

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -211,11 +211,11 @@ var testCases = []struct {
 	{name: "allowedSourceTenantsAndGroupSourceTenantsWithMultipleTenantsAndOneIsMissing", validator: hasAllowedSourceTenants{allowedSourceTenants: []string{"tenant1", "tenant2"}}, group: unmarshaler.RuleGroup{SourceTenants: []string{"tenant1", "tenant3"}}, rule: rulefmt.Rule{Expr: `up{foo="bar"}`}, expectedErrors: 1},
 
 	// hasAllowedEvaluationInterval
-	{name: "validInterval", validator: hasAllowedEvaluationInterval{minimum: time.Second, maximum: time.Minute, mustBeSet: true}, group: unmarshaler.RuleGroup{Interval: model.Duration(time.Minute)}, expectedErrors: 0},
-	{name: "unsetRequiredInterval", validator: hasAllowedEvaluationInterval{minimum: time.Second, maximum: time.Minute, mustBeSet: true}, group: unmarshaler.RuleGroup{Interval: 0}, expectedErrors: 1},
-	{name: "unsetNotRequiredInterval", validator: hasAllowedEvaluationInterval{minimum: time.Second, maximum: time.Minute, mustBeSet: false}, group: unmarshaler.RuleGroup{Interval: 0}, expectedErrors: 0},
-	{name: "tooShortInterval", validator: hasAllowedEvaluationInterval{minimum: time.Minute, maximum: time.Hour, mustBeSet: true}, group: unmarshaler.RuleGroup{Interval: model.Duration(time.Second)}, expectedErrors: 1},
-	{name: "tooHighInterval", validator: hasAllowedEvaluationInterval{minimum: time.Minute, maximum: time.Hour, mustBeSet: true}, group: unmarshaler.RuleGroup{Interval: model.Duration(time.Hour * 2)}, expectedErrors: 1},
+	{name: "validInterval", validator: hasAllowedEvaluationInterval{minimum: model.Duration(time.Second), maximum: model.Duration(time.Minute), mustBeSet: true}, group: unmarshaler.RuleGroup{Interval: model.Duration(time.Minute)}, expectedErrors: 0},
+	{name: "unsetRequiredInterval", validator: hasAllowedEvaluationInterval{minimum: model.Duration(time.Second), maximum: model.Duration(time.Minute), mustBeSet: true}, group: unmarshaler.RuleGroup{Interval: 0}, expectedErrors: 1},
+	{name: "unsetNotRequiredInterval", validator: hasAllowedEvaluationInterval{minimum: model.Duration(time.Second), maximum: model.Duration(time.Minute), mustBeSet: false}, group: unmarshaler.RuleGroup{Interval: 0}, expectedErrors: 0},
+	{name: "tooShortInterval", validator: hasAllowedEvaluationInterval{minimum: model.Duration(time.Minute), maximum: model.Duration(time.Hour), mustBeSet: true}, group: unmarshaler.RuleGroup{Interval: model.Duration(time.Second)}, expectedErrors: 1},
+	{name: "tooHighInterval", validator: hasAllowedEvaluationInterval{minimum: model.Duration(time.Minute), maximum: model.Duration(time.Hour), mustBeSet: true}, group: unmarshaler.RuleGroup{Interval: model.Duration(time.Hour * 2)}, expectedErrors: 1},
 
 	// hasValidPartialStrategy
 	{name: "validPartialStrategy", validator: hasValidPartialStrategy{}, group: unmarshaler.RuleGroup{PartialResponseStrategy: "warn"}, expectedErrors: 0},


### PR DESCRIPTION
Fixes error in validation of the `hasAllowedSourceTenants` params if the `maximum` was not set

default value of the maximum is now set first before the validation

Also change the time.Duration to model.Duration which handles better high durations and its formatting