### PR TITLE
fix: strict unmarshalling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated: Prometheus and other dependencies
 - CI: Updated Github actions for golangcilint and goreleaser
+- Fixed: :warning: Unmarshalling of the rule files is strict again, this behavior was unintentionally brought when adding support for yaml comments.
+- Added: support for alert field `keep_firing_for`
+- Added: support for the `query_offset` field in the rule group
 
 ## [2.14.1]
 - Fixed: error message in the `hasSourceTenantsForMetrics` validator

--- a/pkg/unmarshaler/helpers.go
+++ b/pkg/unmarshaler/helpers.go
@@ -52,6 +52,8 @@ func disabledValidatorsFromComments(comments []string, commentPrefix string) []s
 }
 
 func unmarshalToNodeAndStruct(value, dstNode *yaml.Node, dstStruct interface{}, knownFields []string) error {
+	// Since yaml/v3 Node.Decode doesn't support setting decode options like KnownFields (see https://github.com/go-yaml/yaml/issues/460)
+	// we need to check the fields manually, thus the function requires a list of known fields.
 	if value.Kind == yaml.MappingNode {
 		m := map[string]any{}
 		if err := value.Decode(m); err != nil {
@@ -74,6 +76,7 @@ func unmarshalToNodeAndStruct(value, dstNode *yaml.Node, dstStruct interface{}, 
 	return nil
 }
 
+// mustListStructYamlFieldNames returns a list of yaml field names for the given struct.
 func mustListStructYamlFieldNames(s interface{}) []string {
 	y, err := yaml.Marshal(s)
 	if err != nil {

--- a/pkg/unmarshaler/unmarshaler.go
+++ b/pkg/unmarshaler/unmarshaler.go
@@ -10,6 +10,7 @@ import (
 )
 
 var (
+	// Struct fields marked as omitempty MUST be set to non-default value so they appear in marshalled yaml
 	rulesFileKnownFields         = mustListStructYamlFieldNames(RulesFile{})
 	groupsWithCommentKnownFields = mustListStructYamlFieldNames(GroupsWithComment{})
 	ruleGroupKnownFields         = mustListStructYamlFieldNames(RuleGroup{})

--- a/pkg/unmarshaler/unmarshaler.go
+++ b/pkg/unmarshaler/unmarshaler.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	// Struct fields marked as omitempty MUST be set to non-default value so they appear in marshalled yaml
+	// Struct fields marked as omitempty MUST be set to non-default value so they appear in marshalled yaml.
 	rulesFileKnownFields         = mustListStructYamlFieldNames(RulesFile{})
 	groupsWithCommentKnownFields = mustListStructYamlFieldNames(GroupsWithComment{})
 	ruleGroupKnownFields         = mustListStructYamlFieldNames(RuleGroup{})


### PR DESCRIPTION
/fixes #68

Adds a workaround for missing `KnownFields` option when using `Node.Decode` as described in yaml feaature request here https://github.com/go-yaml/yaml/issues/460

It is hacky, but unfortunately I see no better way to do this :/

Signed-off-by: Martin Chodur <m.chodur@seznam.cz>