### PR TITLE
fix: panic when validation unsupported file type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added: New validation `expressionDoesNotUseClassicHistogramBucketOperations` to avoid queries fragile because of the classic histogram bucket operations.
   See the docs for more info [expressionDoesNotUseClassicHistogramBucketOperations](docs/validations.md#expressiondoesnotuseclassichistogrambucketoperations)
 - Changed: :warning: revert the ENV expansion in config file since it was breaking and caused issues (it was a stupid idea)
+- Fix: Avoid panic when validating unsupported file type and revert to previous behavior when any file was treated as a rule file regardless of the extension.
+       The only exception are `.jsonnet` files that are evaluated first.
 
 ## [3.4.0] - 2024-10-30
 - Fixed: :warning: Ignore white spaces around rule names in the `disabled_validation_rules` annotation CSV format (Thanks @jmichalek13 !)

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ build:
 
 E2E_TESTS_VALIDATIONS_FILE := examples/validation.yaml
 E2E_TESTS_ADDITIONAL_VALIDATIONS_FILE := examples/additional-validation.yaml
-E2E_TESTS_RULES_FILES := examples/rules/*.yaml
+E2E_TESTS_RULES_FILES := examples/rules/*
 E2E_TESTS_DOCS_FILE_MD := examples/human_readable.md
 E2E_TESTS_DOCS_FILE_HTML := examples/human_readable.html
 

--- a/examples/rules/foo.jsonnet
+++ b/examples/rules/foo.jsonnet
@@ -1,0 +1,17 @@
+{
+  groups: [
+    {
+      name: 'foo',
+      limit: 1,
+      rules: [
+        {
+          alert: 'foo',
+          expr: |||
+            # ignore_validations: hasLabels,hasAnyOfAnnotations,hasAnnotations,hasAllowedLimit
+            1
+          |||,
+        },
+      ],
+    },
+  ],
+}

--- a/examples/rules/foo.rules
+++ b/examples/rules/foo.rules
@@ -1,0 +1,6 @@
+# ignore_validations: hasLabels,hasAnyOfAnnotations,hasAnnotations,hasAllowedLimit
+groups:
+    - name: foo
+      rules:
+        - alert: foo
+          expr: 1


### PR DESCRIPTION
fixes https://github.com/FUSAKLA/promruval/issues/94

 - avoid the panic
 - rollback to the former behavior when all file types are validated and treated as rule files yaml regardless of the extension (only exception is `.jsonnet`)
 - add e2e tests to cover such case

Signed-off-by: Martin Chodur <m.chodur@seznam.cz>