### PR TITLE
feat: add  conditional validations

### DIFF
--- a/docs/validations.md
+++ b/docs/validations.md
@@ -3,6 +3,8 @@ All the supported validations are listed here. The validations are grouped by th
 
 > If you want some sane default validations, you can look at the [default_validation.yaml](./default_validation.yaml). Those should be a good starting point for your own configuration and applicable to most of the use cases.
 
+Validations can also be conditional based on various criteria. More information about the conditions can be found [here](#conditional-validation).
+
 - [Supported validations by scopes](#supported-validations-by-scopes)
   - [Groups](#groups)
     - [`hasAllowedSourceTenants`](#hasallowedsourcetenants)
@@ -562,4 +564,31 @@ Fails if the name of the recorded metric matches the specified regular expressio
 ```yaml
 params:
   regexp: "^foo_bar$"
+```
+
+# Conditional validation
+
+Validating the output does not have to be strictly defined but can be based on variable criteria. To achieve this, 
+a `onlyIf` section can be added to the validator, which allows the output to be validated only if **all conditions** 
+in the `onlyIf` array are met.
+
+```yaml
+  - name: critical-alert-escalation-validation
+    scope: Alert
+    validations:
+      - type: hasAnnotations
+        params:
+          annotations: [ "playbook" ]
+        onlyIf:
+          - type: hasLabels
+            params:
+              labels: ["escalate"]
+      - type: hasLabels
+        params:
+          labels: ["escalate"]
+        onlyIf:
+          - type: labelHasAllowedValue
+            params:
+              label: "severity"
+              allowedValues: ["critical", "error"]
 ```

--- a/main.go
+++ b/main.go
@@ -80,7 +80,19 @@ rulesIteration:
 			if newValidator == nil {
 				continue
 			}
-			newRule.AddValidator(newValidator, validatorConfig.AdditionalDetails)
+            var onlyIfValidators []validator.Validator
+            for _, onlyIfValidatorConfig := range validatorConfig.OnlyIf {
+                newOnlyIfValidator, err := validator.NewFromConfig(validationRule.Scope, onlyIfValidatorConfig)
+			    if err != nil {
+				    return nil, fmt.Errorf("loading only if config for validator `%s` in the `%s` rule: %w", onlyIfValidatorConfig.ValidatorType, validationRule.Name, err)
+			    }
+                if newOnlyIfValidator == nil {
+                    continue
+                }
+                onlyIfValidators = append(onlyIfValidators, newOnlyIfValidator)
+            }
+
+			newRule.AddValidator(newValidator, validatorConfig.AdditionalDetails, onlyIfValidators)
 		}
 		validationRules = append(validationRules, newRule)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -122,10 +122,11 @@ type ValidationRule struct {
 }
 
 type ValidatorConfig struct {
-	ValidatorType     string    `yaml:"type"`
-	AdditionalDetails string    `yaml:"additionalDetails"`
-	Params            yaml.Node `yaml:"params"`
-	ParamsFromFile    string    `yaml:"paramsFromFile"`
+	ValidatorType     string    `       yaml:"type"`
+	AdditionalDetails string            `yaml:"additionalDetails"`
+	Params            yaml.Node         `yaml:"params"`
+	ParamsFromFile    string            `yaml:"paramsFromFile"`
+	OnlyIf            []ValidatorConfig `yaml:"onlyIf"`
 }
 
 func (c *ValidatorConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -13,7 +13,7 @@ import (
 type ValidationRule interface {
 	Name() string
 	Scope() config.ValidationScope
-	ValidationTexts() []string
+	ValidationTexts() map[string][]string
 }
 
 func NewValidationReport() *ValidationReport {
@@ -163,8 +163,17 @@ func (r *ValidationReport) AsText(indentationStep int, color bool) (string, erro
 		output.AddLine("")
 		output.AddLine(rule.Name() + ":")
 		output.IncreaseIndentation()
-		for _, check := range rule.ValidationTexts() {
-			output.AddLine("- " + check)
+		for key, values := range rule.ValidationTexts() {
+			output.IncreaseIndentation()
+		    if len(values) > 0 {
+                output.AddLine("- " + key + " - only if: ")
+                for _, value := range values {
+                    output.AddLine("  - " + value)
+                }
+            } else {
+                output.AddLine("- " + key)
+            }
+            output.DecreaseIndentation()
 		}
 		output.DecreaseIndentation()
 	}

--- a/pkg/report/validation.go
+++ b/pkg/report/validation.go
@@ -57,7 +57,7 @@ var customFuncs = template.FuncMap{
 type templateRule struct {
 	Name        string
 	Scope       string
-	Validations []string
+	Validations map[string][]string
 }
 
 type templateData struct {

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -25,6 +25,17 @@ func validateWithDetails(v validationrule.ValidatorWithDetails, group unmarshale
 	var reportedError error
 	validatorName := v.Name()
 	additionalDetails := v.AdditionalDetails()
+    isOnlyIfConditionMet := true
+	for _, onlyIfValidator := range v.OnlyIf() {
+	    errors := onlyIfValidator.Validate(group, rule, prometheusClient)
+	    if len(errors) > 0 {
+	        isOnlyIfConditionMet = false
+	        break
+	    }
+	}
+    if !isOnlyIfConditionMet {
+        return []error{}
+    }
 	validationErrors := v.Validate(group, rule, prometheusClient)
 	errs := make([]error, 0, len(validationErrors))
 	for _, err := range validationErrors {

--- a/pkg/validationrule/validation_rule.go
+++ b/pkg/validationrule/validation_rule.go
@@ -11,12 +11,14 @@ type ValidatorWithDetails interface {
 	validator.Validator
 	AdditionalDetails() string
 	Name() string
+	OnlyIf() []validator.Validator
 }
 
 type validatorWithAdditionalDetails struct {
 	validator.Validator
 	additionalDetails string
 	name              string
+	onlyIf            []validator.Validator
 }
 
 func (v validatorWithAdditionalDetails) AdditionalDetails() string {
@@ -25,6 +27,10 @@ func (v validatorWithAdditionalDetails) AdditionalDetails() string {
 
 func (v validatorWithAdditionalDetails) Name() string {
 	return v.name
+}
+
+func (v validatorWithAdditionalDetails) OnlyIf() []validator.Validator {
+	return v.onlyIf
 }
 
 func New(name string, scope config.ValidationScope) *ValidationRule {
@@ -45,11 +51,12 @@ func (r *ValidationRule) Validators() []ValidatorWithDetails {
 	return r.validators
 }
 
-func (r *ValidationRule) AddValidator(newValidator validator.Validator, additionalDetails string) {
+func (r *ValidationRule) AddValidator(newValidator validator.Validator, additionalDetails string, onlyIf []validator.Validator) {
 	r.validators = append(r.validators, &validatorWithAdditionalDetails{
 		Validator:         newValidator,
 		additionalDetails: additionalDetails,
 		name:              reflect.TypeOf(newValidator).Elem().Name(),
+		onlyIf:            onlyIf,
 	})
 }
 
@@ -61,10 +68,16 @@ func (r *ValidationRule) Scope() config.ValidationScope {
 	return r.scope
 }
 
-func (r *ValidationRule) ValidationTexts() []string {
-	validationTexts := make([]string, 0, len(r.validators))
-	for _, v := range r.validators {
-		validationTexts = append(validationTexts, v.String())
+func (r *ValidationRule) ValidationTexts() map[string][]string {
+	validationTexts := make(map[string][]string, len(r.validators))
+
+	for _, validator := range r.validators {
+		key := validator.String()
+		var value []string
+		for _, onlyIfValidator := range validator.OnlyIf() {
+		    value = append(value, onlyIfValidator.String())
+		}
+		validationTexts[key] = value
 	}
 	return validationTexts
 }


### PR DESCRIPTION
# Adding conditional validations

In some cases, we need to validate certain attributes based on specific conditions. There are situations where an attribute is available or required only under certain circumstances. For example, consider the following scenario where we want to enforce that, for certain alert severities, the `escalate` parameter must always be set, and if the `escalate` parameter is set, the `playbook` parameter must also always be defined. Then the output will also apply to the alerts in the example.

Example configuration:

```yaml
  - name: critical-alert-escalation-validation
    scope: Alert
    validations:
      - type: hasAnnotations
        params:
          annotations: [ "playbook" ]
        onlyIf:
          - type: hasLabels
            params:
              labels: ["escalate"]
      - type: hasLabels
        params:
          labels: ["escalate"]
        onlyIf:
          - type: labelHasAllowedValue
            params:
              label: "severity"
              allowedValues: ["critical", "error"]
```

Example rule file:

```yaml
groups:
- name: group-1  # INVALID - missing escalate label
  rules:
  - alert: alert1
    expr: ...
    labels:
      severity: error
    annotations:
      title: ...
      description:...
      playbook: ...

- name: group-2  # INVALID - missing playbook annotation
  rules:
  - alert: alert2
    expr: ...
    labels:
      severity: error
      escalate: ...
    annotations:
      title: ...
      description:... 

- name: group-3  # VALID - all conditions has been met
  rules:
  - alert:alert3
    expr: ...
    labels:
      severity: error
      escalate: ...
    annotations:
      title: ...
      playbook: ...
```

Example output from promruval:

```
INFO[2025-01-28T07:24:36+01:00] processing file                               file=./rules.yaml.yaml progress=1/1
Validation rules used:
  
  critical-alert-escalation-validation:
      - has all of these annotations: `playbook` - only if: 
        - has labels: `escalate`
      - has labels: `escalate` - only if: 
        - label `severity` has one of the allowed values: `critical`,`error`


Result: 
  File: ./rules.yaml - INVALID
    Group:  group-1
      Group level errors:
      Alert: ...
        - hasLabels: missing label `escalate`
    Group: group-2
      Group level errors:
      Alert: ...
        - hasAnnotations: missing annotation `playbook`


Validation FAILED
Statistics:
  Duration: 340.609602ms
  Files: 1 and 0 of them excluded
  Groups: 3 and 0 of them excluded
  Rules: 3 and 0 of them excluded
```