### PR TITLE
fix: expressionDoesNotUseClassicHistogramBucketOperations internalize…

### DIFF
--- a/pkg/validator/config.go
+++ b/pkg/validator/config.go
@@ -37,7 +37,7 @@ var registeredUniversalRuleValidators = map[string]validatorCreator{
 	"expressionIsWellFormatted":                            newExpressionIsWellFormatted,
 	"expressionUsesUnderscoresInLargeNumbers":              newExpressionUsesUnderscoresInLargeNumbers,
 	"expressionDoesNotUseExperimentalFunctions":            newExpressionDoesNotUseExperimentalFunctions,
-	"expressionDoesNotUseClassicHistogramBucketOperations": newExpressionDoesNotUseOperationsBetweenClassicHistogramBuckets,
+	"expressionDoesNotUseClassicHistogramBucketOperations": newExpressionDoesNotUseClassicHistogramBucketOperations,
 
 	// LogQL
 	"expressionIsValidLogQL":              newExpressionIsValidLogQL,

--- a/pkg/validator/promql_expression.go
+++ b/pkg/validator/promql_expression.go
@@ -660,17 +660,17 @@ func (h expressionUsesUnderscoresInLargeNumbers) Validate(_ unmarshaler.RuleGrou
 	return []error{}
 }
 
-func newExpressionDoesNotUseOperationsBetweenClassicHistogramBuckets(paramsConfig yaml.Node) (Validator, error) {
+func newExpressionDoesNotUseClassicHistogramBucketOperations(paramsConfig yaml.Node) (Validator, error) {
 	params := struct{}{}
 	if err := paramsConfig.Decode(&params); err != nil {
 		return nil, err
 	}
-	return &expressionDoesNotUseOperationsBetweenClassicHistogramBuckets{}, nil
+	return &expressionDoesNotUseClassicHistogramBucketOperations{}, nil
 }
 
-type expressionDoesNotUseOperationsBetweenClassicHistogramBuckets struct{}
+type expressionDoesNotUseClassicHistogramBucketOperations struct{}
 
-func (h expressionDoesNotUseOperationsBetweenClassicHistogramBuckets) String() string {
+func (h expressionDoesNotUseClassicHistogramBucketOperations) String() string {
 	return "expression does not do any binary operations between histogram buckets, it can be dangerous because of inconsistency in the data if sent over remote write for example"
 }
 
@@ -679,7 +679,7 @@ const (
 	histogramBucketLabelName = "le"
 )
 
-func (h expressionDoesNotUseOperationsBetweenClassicHistogramBuckets) Validate(_ unmarshaler.RuleGroup, rule rulefmt.Rule, _ *prometheus.Client) []error {
+func (h expressionDoesNotUseClassicHistogramBucketOperations) Validate(_ unmarshaler.RuleGroup, rule rulefmt.Rule, _ *prometheus.Client) []error {
 	promQl, err := parser.ParseExpr(rule.Expr)
 	if err != nil {
 		return []error{fmt.Errorf("failed to parse expression `%s`: %w", rule.Expr, err)}

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -322,10 +322,10 @@ var testCases = []struct {
 	{name: "expressionUsesUnderscoresInLargeNumbers_valid_exp", validator: expressionUsesUnderscoresInLargeNumbers{}, rule: rulefmt.Rule{Expr: `vector(time())  > 10e12`}, expectedErrors: 0},
 	{name: "expressionUsesUnderscoresInLargeNumbers_invalid", validator: expressionUsesUnderscoresInLargeNumbers{}, rule: rulefmt.Rule{Expr: `time() > 1000`}, expectedErrors: 1},
 
-	// expressionDoesNotUseOperationsBetweenClassicHistogramBuckets
-	{name: "expressionDoesNotUseOperationsBetweenClassicHistogramBuckets_valid", validator: expressionDoesNotUseOperationsBetweenClassicHistogramBuckets{}, rule: rulefmt.Rule{Expr: `foo_bucket{le="+Inf"} - bar_bucket{le="1"}`}, expectedErrors: 0},
-	{name: "expressionDoesNotUseOperationsBetweenClassicHistogramBuckets_invalid", validator: expressionDoesNotUseOperationsBetweenClassicHistogramBuckets{}, rule: rulefmt.Rule{Expr: `request_duration_seconds_bucket{le="+Inf"} - ignoring(le) request_duration_seconds_bucket{le="1"}`}, expectedErrors: 1},
-	{name: "expressionDoesNotUseOperationsBetweenClassicHistogramBuckets_complicated_valid", validator: expressionDoesNotUseOperationsBetweenClassicHistogramBuckets{}, rule: rulefmt.Rule{Expr: `(request_duration_seconds_bucket{app="foo", le="+Inf"} * up{app="foo"}) - ignoring(le) request_duration_seconds_bucket{le="1"}`}, expectedErrors: 0},
+	// expressionDoesNotUseClassicHistogramBucketOperations
+	{name: "expressionDoesNotUseClassicHistogramBucketOperations_valid", validator: expressionDoesNotUseClassicHistogramBucketOperations{}, rule: rulefmt.Rule{Expr: `foo_bucket{le="+Inf"} - bar_bucket{le="1"}`}, expectedErrors: 0},
+	{name: "expressionDoesNotUseClassicHistogramBucketOperations_invalid", validator: expressionDoesNotUseClassicHistogramBucketOperations{}, rule: rulefmt.Rule{Expr: `request_duration_seconds_bucket{le="+Inf"} - ignoring(le) request_duration_seconds_bucket{le="1"}`}, expectedErrors: 1},
+	{name: "expressionDoesNotUseClassicHistogramBucketOperations_complicated_valid", validator: expressionDoesNotUseClassicHistogramBucketOperations{}, rule: rulefmt.Rule{Expr: `(request_duration_seconds_bucket{app="foo", le="+Inf"} * up{app="foo"}) - ignoring(le) request_duration_seconds_bucket{le="1"}`}, expectedErrors: 0},
 }
 
 func Test(t *testing.T) {


### PR DESCRIPTION
…d name to allow ignore_validation

As its not the string key used in `validatorCreator` what is used as a validator `.Name()`, it is currently not possible to skip validation for `expressionDoesNotUseClassicHistogramBucketOperations`, unless `expressionDoesNotUseClassicHistogramBucketOperations` is used in configuration and `expressionDoesNotUseOperationsBetweenClassicHistogramBuckets` in `ignore_validations` comment. I assume it is better to change the internal structure name, rather than the name which is used in changelog and documentation.