### PR TITLE
refactor: defaults for regexps

### DIFF
--- a/docs/validations.md
+++ b/docs/validations.md
@@ -3,6 +3,8 @@ All the supported validations are listed here. The validations are grouped by th
 
 > If you want some sane default validations, you can look at the [default_validation.yaml](./default_validation.yaml). Those should be a good starting point for your own configuration and applicable to most of the use cases.
 
+> Please note that unless explicitly stated otherwise, all regular expressions used in configuration are fully anchored `^...$` and defaults to match everything `.*`.
+
 - [Supported validations by scopes](#supported-validations-by-scopes)
   - [Groups](#groups)
     - [`hasAllowedSourceTenants`](#hasallowedsourcetenants)
@@ -138,7 +140,7 @@ Fails if the group name does not match the specified regular expression.
 
 ```yaml
 params:
-  regexp: "[A-Z]\s+"
+  regexp: "[A-Z]\s+" # defaults to ""
 ```
 
 ### `hasAllowedQueryOffset`
@@ -198,7 +200,7 @@ Fails if rule label does not match the specified regular expression.
 ```yaml
 params:
   label: "foo"
-  regexp: ".*"
+  regexp: ".*" # defaults to ""
 ```
 
 #### `labelHasAllowedValue`
@@ -249,7 +251,7 @@ Fails if the rule expression uses any of the experimental PromQL functions.
 
 #### `expressionDoesNotUseMetrics`
 
-Fails if the rule expression uses metrics matching any of the metric name fully anchored(will be surrounded by `^...$`) regexps.
+Fails if the rule expression uses metrics matching any of the metric name regexps. Empty list does not match anything. All regexps within the list will be fully anchored (surrounded by `^...$`), empty string (`""`) **won't be converted to all match (`.*`)**.
 > If you want to avoid using some metrics in the rules, you can use this validation to make sure it won't happen.
 
 ```yaml
@@ -279,7 +281,7 @@ The check rather ignores validation of labels, where it cannot be sure if they a
 
 ```yaml
 params:
-  metricNameRegexp: "kube_pod_labels" # The regexp will be fully anchored (surrounded by ^...$)
+  metricNameRegexp: "kube_pod_labels"
   allowedLabels: [ "pod", "cluster", "app", "team" ]
 ```
 
@@ -293,7 +295,7 @@ The check rather ignores validation of labels, where it cannot be sure if they a
 
 ```yaml
 params:
-  metricNameRegexp: "kube_.+" # The regexp will be fully anchored (surrounded by ^...$)
+  metricNameRegexp: "kube_.+"
   labels: [ "job", "cluster", "app", "instance" ]
 ```
 
@@ -302,7 +304,7 @@ Fails if the metrics matching given regexp uses label selectors for given labels
 
 ```yaml
 params:
-  metricNameRegexp: "kube_pod_labels" # The regexp will be fully anchored (surrounded by ^...$), defaults to ^.*$ if not configured or empty.
+  metricNameRegexp: "kube_pod_labels"
   allowedLabelValues:
     cluster: ['kube1', 'kube2', 'kube3']
     team: ['sre', 'backend']
@@ -435,8 +437,8 @@ params:
   defaultTenant: <tenant_name> # Optional, if set, the tenant that will be assumed if the group does not have the `source_tenants` option set
   sourceTenants:
     <tenant_name>:
-      - regexp: <metric_name_regexp> # The regexp will be fully anchored (surrounded by ^...$)
-        negativeRegexp: <metric_name_regexp> # Optional, metrics matching the regexp will be excluded from the check, will be fully anchored (surrounded by ^...$)
+      - regexp: <metric_name_regexp>
+        negativeRegexp: <metric_name_regexp> # Optional, metrics matching the regexp will be excluded from the check, defaults to ""
         description: <description> # Optional, will be shown in the validator output human-readable description
   # Example:
   # k8s:
@@ -579,7 +581,7 @@ Fails if the name of the recorded metric does not match the specified regular ex
 
 ```yaml
 params:
-  regexp: "[^:]+:[^:]+:[^:]+"
+  regexp: "[^:]+:[^:]+:[^:]+" # defaults to ""
 ```
 
 #### `recordedMetricNameDoesNotMatchRegexp`
@@ -588,5 +590,5 @@ Fails if the name of the recorded metric matches the specified regular expressio
 
 ```yaml
 params:
-  regexp: "^foo_bar$"
+  regexp: "^foo_bar$" # defaults to ""
 ```

--- a/examples/human_readable.html
+++ b/examples/human_readable.html
@@ -1,101 +1,97 @@
-<h1>Validation rules</h1>
-<br />
-<h2><a href="#check-severity-label">check-severity-label</a></h2>
-<h4>Following conditions MUST be met:</h4>
-<ul>
-	<li>Alert has labels: <code>severity</code></li>
-	<li>Alert label <code>severity</code> has one of the allowed values:
-		<code>info</code>,<code>warning</code>,<code>critical</code></li>
-	<li>Alert if rule has label <code>severity</code> with value <code>info</code> , it cannot have label
-		<code>page</code></li>
-	<li>Alert expression does not use irate</li>
-	<li>Alert expression does not use data older than <code>6h0m0s</code></li>
-</ul>
-<br />
-<h2><a href="#check-team-label">check-team-label</a></h2>
-<h4>Following conditions MUST be met:</h4>
-<ul>
-	<li>Alert has labels: <code>xxx</code></li>
-	<li>Alert label <code>team</code> has one of the allowed values: <code>sre@company.com</code> (templated values are
-		ignored)</li>
-</ul>
-<br />
-<h2><a href="#check-playbook-annotation">check-playbook-annotation</a></h2>
-<h4>Following conditions MUST be met:</h4>
-<ul>
-	<li>Alert has any of these annotations: <code>playbook</code>,<code>link</code></li>
-	<li>Alert Annotation <code>link</code> is a valid URL and does not return HTTP status 404</li>
-</ul>
-<br />
-<h2><a href="#check-alert-title">check-alert-title</a></h2>
-<h4>Following conditions MUST be met:</h4>
-<ul>
-	<li>Alert has all of these annotations: <code>title</code></li>
-</ul>
-<br />
-<h2><a href="#check-prometheus-limitations">check-prometheus-limitations</a></h2>
-<h4>Following conditions MUST be met:</h4>
-<ul>
-	<li>Rule expression does not use any experimental PromQL functions</li>
-	<li>Rule expression uses underscores as separators in large numbers in PromQL expression. Example: 1_000_000</li>
-	<li>Rule expression does not use data older than <code>6h0m0s</code></li>
-	<li>Rule does not use any of the
-		<code>cluster</code>,<code>locality</code>,<code>prometheus-type</code>,<code>replica</code> labels is in its
-		expression</li>
-</ul>
-<br />
-<h2><a href="#check-metric-name">check-metric-name</a></h2>
-<h4>Following conditions MUST be met:</h4>
-<ul>
-	<li>Alert expression uses metric name in selectors</li>
-	<li>Alert labels are valid templates</li>
-	<li>Alert <code>keep_firing_for</code> is not longer than <code>1h</code></li>
-</ul>
-<br />
-<h2><a href="#check-groups">check-groups</a></h2>
-<h4>Following conditions MUST be met:</h4>
-<ul>
-	<li>Group evaluation interval is between <code>20s</code> and <code>106751d23h47m16s854ms</code> if set</li>
-	<li>Group has at most 10 rules</li>
-	<li>Group does not have higher <code>limit</code> configured then 100</li>
-</ul>
-<br />
-<h2><a href="#check-formatting">check-formatting</a></h2>
-<h4>Following conditions MUST be met:</h4>
-<ul>
-	<li>Rule expression is well formatted as would <code>promtool promql format</code> do or similar online tool such as
-		https://o11y.tools/promqlparser/</li>
-	<li>Rule expression does not do any binary operations between histogram buckets, it can be dangerous because of
-		inconsistency in the data if sent over remote write for example</li>
-</ul>
-<br />
-<h2><a href="#check-recording-rules">check-recording-rules</a></h2>
-<h4>Following conditions MUST be met:</h4>
-<ul>
-	<li>Recording rule recorded metric name does not match regexp: <code>^foo_bar$</code></li>
-	<li>Recording rule recorded metric name matches regexp: <code>[^:]+:[^:]+:[^:]+</code></li>
-</ul>
-<br />
-<h2><a href="#test-onlyif">test-onlyif</a></h2>
-<h4>Only if ALL the following conditions are met:</h4>
-<ul>
-	<li>Rule label <code>severity</code> matches regexp <code>^critical$</code></li>
-	<li>Group has at most 1 rules</li>
-</ul>
-<h4>Following conditions MUST be met:</h4>
-<ul>
-	<li>Alert has labels: <code>escalate</code></li>
-</ul>
-<br />
-<h2><a href="#check-labels-in-expr">check-labels-in-expr</a></h2>
-<ul>
-	<li>All rules for metrics matching regexp '^up$', given lables use only specified values: job: [prometheus]
-	</li>
-	<li>All rules expression does not use labels <code>app</code> for metrics matching regexp ^up$ in the expr</li>
-</ul>
 
-<h2><a href="#another-checks">another-checks</a></h2>
-<h4>Following conditions MUST be met:</h4>
-<ul>
-	<li>Rule labels does not have empty values</li>
-</ul>
+<h1>Validation rules</h1>
+  <br/>
+  <h2><a href="#check-severity-label">check-severity-label</a></h2>
+	  <h4>Following conditions MUST be met:</h4>
+	  <ul>
+		<li>Alert has labels: <code>severity</code></li>
+		<li>Alert label <code>severity</code> has one of the allowed values: <code>info</code>,<code>warning</code>,<code>critical</code></li>
+		<li>Alert if rule has label <code>severity</code> with value <code>info</code> , it cannot have label <code>page</code></li>
+		<li>Alert expression does not use irate</li>
+		<li>Alert expression does not use data older than <code>6h0m0s</code></li>
+	  </ul>
+  <br/>
+  <h2><a href="#check-team-label">check-team-label</a></h2>
+	  <h4>Following conditions MUST be met:</h4>
+	  <ul>
+		<li>Alert has labels: <code>xxx</code></li>
+		<li>Alert label <code>team</code> has one of the allowed values: <code>sre@company.com</code> (templated values are ignored)</li>
+	  </ul>
+  <br/>
+  <h2><a href="#check-playbook-annotation">check-playbook-annotation</a></h2>
+	  <h4>Following conditions MUST be met:</h4>
+	  <ul>
+		<li>Alert has any of these annotations: <code>playbook</code>,<code>link</code></li>
+		<li>Alert Annotation <code>link</code> is a valid URL and does not return HTTP status 404</li>
+	  </ul>
+  <br/>
+  <h2><a href="#check-alert-title">check-alert-title</a></h2>
+	  <h4>Following conditions MUST be met:</h4>
+	  <ul>
+		<li>Alert has all of these annotations: <code>title</code></li>
+	  </ul>
+  <br/>
+  <h2><a href="#check-prometheus-limitations">check-prometheus-limitations</a></h2>
+	  <h4>Following conditions MUST be met:</h4>
+	  <ul>
+		<li>Rule expression does not use any experimental PromQL functions</li>
+		<li>Rule expression uses underscores as separators in large numbers in PromQL expression. Example: 1_000_000</li>
+		<li>Rule expression does not use data older than <code>6h0m0s</code></li>
+		<li>Rule does not use any of the <code>cluster</code>,<code>locality</code>,<code>prometheus-type</code>,<code>replica</code> labels is in its expression</li>
+	  </ul>
+  <br/>
+  <h2><a href="#check-metric-name">check-metric-name</a></h2>
+	  <h4>Following conditions MUST be met:</h4>
+	  <ul>
+		<li>Alert expression uses metric name in selectors</li>
+		<li>Alert labels are valid templates</li>
+		<li>Alert <code>keep_firing_for</code> is not longer than <code>1h</code></li>
+	  </ul>
+  <br/>
+  <h2><a href="#check-groups">check-groups</a></h2>
+	  <h4>Following conditions MUST be met:</h4>
+	  <ul>
+		<li>Group evaluation interval is between <code>20s</code> and <code>106751d23h47m16s854ms</code> if set</li>
+		<li>Group has at most 10 rules</li>
+		<li>Group does not have higher <code>limit</code> configured then 100</li>
+	  </ul>
+  <br/>
+  <h2><a href="#check-formatting">check-formatting</a></h2>
+	  <h4>Following conditions MUST be met:</h4>
+	  <ul>
+		<li>Rule expression is well formatted as would <code>promtool promql format</code> do or similar online tool such as https://o11y.tools/promqlparser/</li>
+		<li>Rule expression does not do any binary operations between histogram buckets, it can be dangerous because of inconsistency in the data if sent over remote write for example</li>
+	  </ul>
+  <br/>
+  <h2><a href="#check-recording-rules">check-recording-rules</a></h2>
+	  <h4>Following conditions MUST be met:</h4>
+	  <ul>
+		<li>Recording rule recorded metric name does not match regexp: <code>^foo_bar$</code></li>
+		<li>Recording rule recorded metric name matches regexp: <code>^[^:]+:[^:]+:[^:]+$</code></li>
+	  </ul>
+  <br/>
+  <h2><a href="#check-labels-in-expr">check-labels-in-expr</a></h2>
+	  <h4>Following conditions MUST be met:</h4>
+	  <ul>
+		<li>Rule for metrics matching regexp '^up$', given lables use only specified values: job: [prometheus]
+</li>
+		<li>Rule expression does not use labels <code>app</code> for metrics matching regexp ^up$ in the expr</li>
+	  </ul>
+  <br/>
+  <h2><a href="#test-onlyif">test-onlyif</a></h2>
+  	  <h4>Only if ALL the following conditions are met:</h4>
+	  <ul>
+		<li>Rule label <code>severity</code> matches regexp <code>^critical$</code></li>
+		<li>Group has at most 1 rules</li>
+	  </ul>
+	  <h4>Following conditions MUST be met:</h4>
+	  <ul>
+		<li>Alert has labels: <code>escalate</code></li>
+	  </ul>
+  <br/>
+  <h2><a href="#another-checks">another-checks</a></h2>
+	  <h4>Following conditions MUST be met:</h4>
+	  <ul>
+		<li>Rule labels does not have empty values</li>
+	  </ul>
+

--- a/examples/human_readable.html
+++ b/examples/human_readable.html
@@ -1,96 +1,101 @@
-
 <h1>Validation rules</h1>
-  <br/>
-  <h2><a href="#check-severity-label">check-severity-label</a></h2>
-	  <h4>Following conditions MUST be met:</h4>
-	  <ul>
-		<li>Alert has labels: <code>severity</code></li>
-		<li>Alert label <code>severity</code> has one of the allowed values: <code>info</code>,<code>warning</code>,<code>critical</code></li>
-		<li>Alert if rule has label <code>severity</code> with value <code>info</code> , it cannot have label <code>page</code></li>
-		<li>Alert expression does not use irate</li>
-		<li>Alert expression does not use data older than <code>6h0m0s</code></li>
-	  </ul>
-  <br/>
-  <h2><a href="#check-team-label">check-team-label</a></h2>
-	  <h4>Following conditions MUST be met:</h4>
-	  <ul>
-		<li>Alert has labels: <code>xxx</code></li>
-		<li>Alert label <code>team</code> has one of the allowed values: <code>sre@company.com</code> (templated values are ignored)</li>
-	  </ul>
-  <br/>
-  <h2><a href="#check-playbook-annotation">check-playbook-annotation</a></h2>
-	  <h4>Following conditions MUST be met:</h4>
-	  <ul>
-		<li>Alert has any of these annotations: <code>playbook</code>,<code>link</code></li>
-		<li>Alert Annotation <code>link</code> is a valid URL and does not return HTTP status 404</li>
-	  </ul>
-  <br/>
-  <h2><a href="#check-alert-title">check-alert-title</a></h2>
-	  <h4>Following conditions MUST be met:</h4>
-	  <ul>
-		<li>Alert has all of these annotations: <code>title</code></li>
-	  </ul>
-  <br/>
-  <h2><a href="#check-prometheus-limitations">check-prometheus-limitations</a></h2>
-	  <h4>Following conditions MUST be met:</h4>
-	  <ul>
-		<li>Rule expression does not use any experimental PromQL functions</li>
-		<li>Rule expression uses underscores as separators in large numbers in PromQL expression. Example: 1_000_000</li>
-		<li>Rule expression does not use data older than <code>6h0m0s</code></li>
-		<li>Rule does not use any of the <code>cluster</code>,<code>locality</code>,<code>prometheus-type</code>,<code>replica</code> labels is in its expression</li>
-	  </ul>
-  <br/>
-  <h2><a href="#check-metric-name">check-metric-name</a></h2>
-	  <h4>Following conditions MUST be met:</h4>
-	  <ul>
-		<li>Alert expression uses metric name in selectors</li>
-		<li>Alert labels are valid templates</li>
-		<li>Alert <code>keep_firing_for</code> is not longer than <code>1h</code></li>
-	  </ul>
-  <br/>
-  <h2><a href="#check-groups">check-groups</a></h2>
-	  <h4>Following conditions MUST be met:</h4>
-	  <ul>
-		<li>Group evaluation interval is between <code>20s</code> and <code>106751d23h47m16s854ms</code> if set</li>
-		<li>Group has at most 10 rules</li>
-		<li>Group does not have higher <code>limit</code> configured then 100</li>
-	  </ul>
-  <br/>
-  <h2><a href="#check-formatting">check-formatting</a></h2>
-	  <h4>Following conditions MUST be met:</h4>
-	  <ul>
-		<li>Rule expression is well formatted as would <code>promtool promql format</code> do or similar online tool such as https://o11y.tools/promqlparser/</li>
-		<li>Rule expression does not do any binary operations between histogram buckets, it can be dangerous because of inconsistency in the data if sent over remote write for example</li>
-	  </ul>
-  <br/>
-  <h2><a href="#check-recording-rules">check-recording-rules</a></h2>
-	  <h4>Following conditions MUST be met:</h4>
-	  <ul>
-		<li>Recording rule recorded metric name does not match regexp: <code>^foo_bar$</code></li>
-		<li>Recording rule recorded metric name matches regexp: <code>[^:]+:[^:]+:[^:]+</code></li>
-	  </ul>
-  <br/>
-  <h2><a href="#test-onlyif">test-onlyif</a></h2>
-  	  <h4>Only if ALL the following conditions are met:</h4>
-	  <ul>
-		<li>Rule label <code>severity</code> matches regexp <code>^critical$</code></li>
-		<li>Group has at most 1 rules</li>
-	  </ul>
-	  <h4>Following conditions MUST be met:</h4>
-	  <ul>
-		<li>Alert has labels: <code>escalate</code></li>
-	  </ul>
-  <br/>
-  <h2><a href="#check-labels-in-expr">check-labels-in-expr</a></h2>
-	  <ul>
-		<li>All rules for metrics matching regexp '^up$', given lables use only specified values: job: [prometheus]
-</li>
-		<li>All rules expression does not use labels <code>app</code> for metrics matching regexp ^up$ in the expr</li>
-	  </ul>
+<br />
+<h2><a href="#check-severity-label">check-severity-label</a></h2>
+<h4>Following conditions MUST be met:</h4>
+<ul>
+	<li>Alert has labels: <code>severity</code></li>
+	<li>Alert label <code>severity</code> has one of the allowed values:
+		<code>info</code>,<code>warning</code>,<code>critical</code></li>
+	<li>Alert if rule has label <code>severity</code> with value <code>info</code> , it cannot have label
+		<code>page</code></li>
+	<li>Alert expression does not use irate</li>
+	<li>Alert expression does not use data older than <code>6h0m0s</code></li>
+</ul>
+<br />
+<h2><a href="#check-team-label">check-team-label</a></h2>
+<h4>Following conditions MUST be met:</h4>
+<ul>
+	<li>Alert has labels: <code>xxx</code></li>
+	<li>Alert label <code>team</code> has one of the allowed values: <code>sre@company.com</code> (templated values are
+		ignored)</li>
+</ul>
+<br />
+<h2><a href="#check-playbook-annotation">check-playbook-annotation</a></h2>
+<h4>Following conditions MUST be met:</h4>
+<ul>
+	<li>Alert has any of these annotations: <code>playbook</code>,<code>link</code></li>
+	<li>Alert Annotation <code>link</code> is a valid URL and does not return HTTP status 404</li>
+</ul>
+<br />
+<h2><a href="#check-alert-title">check-alert-title</a></h2>
+<h4>Following conditions MUST be met:</h4>
+<ul>
+	<li>Alert has all of these annotations: <code>title</code></li>
+</ul>
+<br />
+<h2><a href="#check-prometheus-limitations">check-prometheus-limitations</a></h2>
+<h4>Following conditions MUST be met:</h4>
+<ul>
+	<li>Rule expression does not use any experimental PromQL functions</li>
+	<li>Rule expression uses underscores as separators in large numbers in PromQL expression. Example: 1_000_000</li>
+	<li>Rule expression does not use data older than <code>6h0m0s</code></li>
+	<li>Rule does not use any of the
+		<code>cluster</code>,<code>locality</code>,<code>prometheus-type</code>,<code>replica</code> labels is in its
+		expression</li>
+</ul>
+<br />
+<h2><a href="#check-metric-name">check-metric-name</a></h2>
+<h4>Following conditions MUST be met:</h4>
+<ul>
+	<li>Alert expression uses metric name in selectors</li>
+	<li>Alert labels are valid templates</li>
+	<li>Alert <code>keep_firing_for</code> is not longer than <code>1h</code></li>
+</ul>
+<br />
+<h2><a href="#check-groups">check-groups</a></h2>
+<h4>Following conditions MUST be met:</h4>
+<ul>
+	<li>Group evaluation interval is between <code>20s</code> and <code>106751d23h47m16s854ms</code> if set</li>
+	<li>Group has at most 10 rules</li>
+	<li>Group does not have higher <code>limit</code> configured then 100</li>
+</ul>
+<br />
+<h2><a href="#check-formatting">check-formatting</a></h2>
+<h4>Following conditions MUST be met:</h4>
+<ul>
+	<li>Rule expression is well formatted as would <code>promtool promql format</code> do or similar online tool such as
+		https://o11y.tools/promqlparser/</li>
+	<li>Rule expression does not do any binary operations between histogram buckets, it can be dangerous because of
+		inconsistency in the data if sent over remote write for example</li>
+</ul>
+<br />
+<h2><a href="#check-recording-rules">check-recording-rules</a></h2>
+<h4>Following conditions MUST be met:</h4>
+<ul>
+	<li>Recording rule recorded metric name does not match regexp: <code>^foo_bar$</code></li>
+	<li>Recording rule recorded metric name matches regexp: <code>[^:]+:[^:]+:[^:]+</code></li>
+</ul>
+<br />
+<h2><a href="#test-onlyif">test-onlyif</a></h2>
+<h4>Only if ALL the following conditions are met:</h4>
+<ul>
+	<li>Rule label <code>severity</code> matches regexp <code>^critical$</code></li>
+	<li>Group has at most 1 rules</li>
+</ul>
+<h4>Following conditions MUST be met:</h4>
+<ul>
+	<li>Alert has labels: <code>escalate</code></li>
+</ul>
+<br />
+<h2><a href="#check-labels-in-expr">check-labels-in-expr</a></h2>
+<ul>
+	<li>All rules for metrics matching regexp '^up$', given lables use only specified values: job: [prometheus]
+	</li>
+	<li>All rules expression does not use labels <code>app</code> for metrics matching regexp ^up$ in the expr</li>
+</ul>
 
-  <h2><a href="#another-checks">another-checks</a></h2>
-	  <h4>Following conditions MUST be met:</h4>
-	  <ul>
-		<li>Rule labels does not have empty values</li>
-	  </ul>
-
+<h2><a href="#another-checks">another-checks</a></h2>
+<h4>Following conditions MUST be met:</h4>
+<ul>
+	<li>Rule labels does not have empty values</li>
+</ul>

--- a/examples/human_readable.md
+++ b/examples/human_readable.md
@@ -47,8 +47,8 @@
   - Rule expression does not do any binary operations between histogram buckets, it can be dangerous because of inconsistency in the data if sent over remote write for example
 
   check-recording-rules
-    - Recording rule Recorded metric name does not match regexp: ^foo_bar$
-    - Recording rule Recorded metric name matches regexp: [^:]&#43;:[^:]&#43;:[^:]&#43;
+    - Recording rule Recorded metric name does not match regexp: ^^foo_bar$$
+    - Recording rule Recorded metric name matches regexp: ^[^:]&#43;:[^:]&#43;:[^:]&#43;$
 
   check-labels-in-expr
     - All rules for metrics matching regexp &#39;^up$&#39;, given lables use only specified values: job: [prometheus]

--- a/examples/human_readable.md
+++ b/examples/human_readable.md
@@ -1,12 +1,13 @@
 
 # Validation rules
 
-  check-severity-label
-    - Alert has labels: `severity`
-    - Alert label `severity` has one of the allowed values: `info`,`warning`,`critical`
-    - Alert if rule has label `severity` with value `info` , it cannot have label `page`
-    - Alert expression does not use irate
-    - Alert expression does not use data older than `6h0m0s`
+## check-severity-label
+#### Following conditions MUST be met:
+  - Alert has labels: `severity`
+  - Alert label `severity` has one of the allowed values: `info`,`warning`,`critical`
+  - Alert if rule has label `severity` with value `info` , it cannot have label `page`
+  - Alert expression does not use irate
+  - Alert expression does not use data older than `6h0m0s`
 
 ## check-team-label
 #### Following conditions MUST be met:
@@ -46,15 +47,25 @@
   - Rule expression is well formatted as would `promtool promql format` do or similar online tool such as https://o11y.tools/promqlparser/
   - Rule expression does not do any binary operations between histogram buckets, it can be dangerous because of inconsistency in the data if sent over remote write for example
 
-  check-recording-rules
-    - Recording rule Recorded metric name does not match regexp: ^^foo_bar$$
-    - Recording rule Recorded metric name matches regexp: ^[^:]&#43;:[^:]&#43;:[^:]&#43;$
+## check-recording-rules
+#### Following conditions MUST be met:
+  - Recording rule recorded metric name does not match regexp: `^foo_bar$`
+  - Recording rule recorded metric name matches regexp: `^[^:]+:[^:]+:[^:]+$`
 
-  check-labels-in-expr
-    - All rules for metrics matching regexp &#39;^up$&#39;, given lables use only specified values: job: [prometheus]
+## check-labels-in-expr
+#### Following conditions MUST be met:
+  - Rule for metrics matching regexp '^up$', given lables use only specified values: job: [prometheus]
 
-    - All rules expression does not use labels `app` for metrics matching regexp ^up$ in the expr
+  - Rule expression does not use labels `app` for metrics matching regexp ^up$ in the expr
 
-  another-checks
-    - All rules labels does not have empty values
+## test-onlyif
+#### Only if ALL the following conditions are met:
+  - Rule label `severity` matches regexp `^critical$`
+  - Group has at most 1 rules
+#### Following conditions MUST be met:
+  - Alert has labels: `escalate`
+
+## another-checks
+#### Following conditions MUST be met:
+  - Rule labels does not have empty values
 

--- a/examples/human_readable.txt
+++ b/examples/human_readable.txt
@@ -50,7 +50,13 @@ Validation rules:
   check-recording-rules (Recording rule)
     Following conditions MUST be met:
       - Recording rule recorded metric name does not match regexp: `^foo_bar$`
-      - Recording rule recorded metric name matches regexp: `[^:]+:[^:]+:[^:]+`
+      - Recording rule recorded metric name matches regexp: `^[^:]+:[^:]+:[^:]+$`
+
+  check-labels-in-expr (All rules)
+    Following conditions MUST be met:
+      - Rule for metrics matching regexp '^up$', given lables use only specified values: job: [prometheus]
+
+      - Rule expression does not use labels `app` for metrics matching regexp ^up$ in the expr
 
   test-onlyif (Alert)
     Only if ALL the following conditions are met:

--- a/examples/validation.yaml
+++ b/examples/validation.yaml
@@ -113,7 +113,7 @@ validationRules:
     validations:
       - type: recordedMetricNameDoesNotMatchRegexp
         params:
-          regexp: "^foo_bar$"
+          regexp: "foo_bar"
       - type: recordedMetricNameMatchesRegexp
         params:
           regexp: "[^:]+:[^:]+:[^:]+"
@@ -138,7 +138,7 @@ validationRules:
       - type: labelMatchesRegexp
         params:
           label: "severity"
-          regexp: "^critical$"
+          regexp: "critical"
       - type: maxRulesPerGroup
         params:
           limit: 1

--- a/pkg/validator/alert.go
+++ b/pkg/validator/alert.go
@@ -112,7 +112,7 @@ func newAlertNameMatchesRegexp(paramsConfig yaml.Node) (Validator, error) {
 	if params.Regexp == "" {
 		return nil, fmt.Errorf("missing pattern")
 	}
-	r, err := compileAnchoredRegexpWithDefault(params.Regexp, "")
+	r, err := compileAnchoredRegexpWithDefault(params.Regexp, emptyRegexp)
 	if err != nil {
 		return nil, fmt.Errorf("invalid pattern %s: %w", params.Regexp, err)
 	}

--- a/pkg/validator/alert.go
+++ b/pkg/validator/alert.go
@@ -104,7 +104,7 @@ func (h validateLabelTemplates) Validate(_ unmarshaler.RuleGroup, rule rulefmt.R
 
 func newAlertNameMatchesRegexp(paramsConfig yaml.Node) (Validator, error) {
 	params := struct {
-		Regexp string `yaml:"regexp"`
+		Regexp RegexpEmptyDefault `yaml:"regexp"`
 	}{}
 	if err := paramsConfig.Decode(&params); err != nil {
 		return nil, err
@@ -112,7 +112,7 @@ func newAlertNameMatchesRegexp(paramsConfig yaml.Node) (Validator, error) {
 	if params.Regexp == "" {
 		return nil, fmt.Errorf("missing pattern")
 	}
-	r, err := compileAnchoredRegexpWithDefault(params.Regexp, emptyRegexp)
+	r, err := compileAnchoredRegexp(params.Regexp)
 	if err != nil {
 		return nil, fmt.Errorf("invalid pattern %s: %w", params.Regexp, err)
 	}

--- a/pkg/validator/alert.go
+++ b/pkg/validator/alert.go
@@ -104,20 +104,13 @@ func (h validateLabelTemplates) Validate(_ unmarshaler.RuleGroup, rule rulefmt.R
 
 func newAlertNameMatchesRegexp(paramsConfig yaml.Node) (Validator, error) {
 	params := struct {
-		Regexp RegexpEmptyDefault `yaml:"regexp"`
+		Regexp RegexpForbidEmpty `yaml:"regexp"`
 	}{}
 	if err := paramsConfig.Decode(&params); err != nil {
 		return nil, err
 	}
-	if params.Regexp == "" {
-		return nil, fmt.Errorf("missing pattern")
-	}
-	r, err := compileAnchoredRegexp(params.Regexp)
-	if err != nil {
-		return nil, fmt.Errorf("invalid pattern %s: %w", params.Regexp, err)
-	}
 	return &alertNameMatchesRegexp{
-		pattern: r,
+		pattern: params.Regexp.Regexp,
 	}, nil
 }
 

--- a/pkg/validator/alert.go
+++ b/pkg/validator/alert.go
@@ -112,7 +112,7 @@ func newAlertNameMatchesRegexp(paramsConfig yaml.Node) (Validator, error) {
 	if params.Regexp == "" {
 		return nil, fmt.Errorf("missing pattern")
 	}
-	r, err := regexp.Compile(params.Regexp)
+	r, err := compileAnchoredRegexpWithDefault(params.Regexp, "")
 	if err != nil {
 		return nil, fmt.Errorf("invalid pattern %s: %w", params.Regexp, err)
 	}

--- a/pkg/validator/annotations.go
+++ b/pkg/validator/annotations.go
@@ -124,12 +124,7 @@ func newAnnotationMatchesRegexp(paramsConfig yaml.Node) (Validator, error) {
 	if params.Annotation == "" {
 		return nil, fmt.Errorf("missing annotation")
 	}
-	expr, err := compileAnchoredRegexp(params.Regexp)
-	if err != nil {
-		return nil, fmt.Errorf("invalid regexp %s", params.Regexp)
-	}
-
-	return &annotationMatchesRegexp{annotation: params.Annotation, regexp: expr}, nil
+	return &annotationMatchesRegexp{annotation: params.Annotation, regexp: params.Regexp.Regexp}, nil
 }
 
 type annotationMatchesRegexp struct {

--- a/pkg/validator/annotations.go
+++ b/pkg/validator/annotations.go
@@ -124,7 +124,7 @@ func newAnnotationMatchesRegexp(paramsConfig yaml.Node) (Validator, error) {
 	if params.Annotation == "" {
 		return nil, fmt.Errorf("missing annotation")
 	}
-	expr, err := compileAnchoredRegexpWithDefault(params.Regexp, "")
+	expr, err := compileAnchoredRegexpWithDefault(params.Regexp, emptyRegexp)
 	if err != nil {
 		return nil, fmt.Errorf("invalid regexp %s", params.Regexp)
 	}

--- a/pkg/validator/annotations.go
+++ b/pkg/validator/annotations.go
@@ -115,8 +115,8 @@ func (h hasAnyOfAnnotations) Validate(_ unmarshaler.RuleGroup, rule rulefmt.Rule
 
 func newAnnotationMatchesRegexp(paramsConfig yaml.Node) (Validator, error) {
 	params := struct {
-		Annotation string `yaml:"annotation"`
-		Regexp     string `yaml:"regexp"`
+		Annotation string             `yaml:"annotation"`
+		Regexp     RegexpEmptyDefault `yaml:"regexp"`
 	}{}
 	if err := paramsConfig.Decode(&params); err != nil {
 		return nil, err
@@ -124,7 +124,7 @@ func newAnnotationMatchesRegexp(paramsConfig yaml.Node) (Validator, error) {
 	if params.Annotation == "" {
 		return nil, fmt.Errorf("missing annotation")
 	}
-	expr, err := compileAnchoredRegexpWithDefault(params.Regexp, emptyRegexp)
+	expr, err := compileAnchoredRegexp(params.Regexp)
 	if err != nil {
 		return nil, fmt.Errorf("invalid regexp %s", params.Regexp)
 	}

--- a/pkg/validator/annotations.go
+++ b/pkg/validator/annotations.go
@@ -124,7 +124,7 @@ func newAnnotationMatchesRegexp(paramsConfig yaml.Node) (Validator, error) {
 	if params.Annotation == "" {
 		return nil, fmt.Errorf("missing annotation")
 	}
-	expr, err := regexp.Compile(params.Regexp)
+	expr, err := compileAnchoredRegexpWithDefault(params.Regexp, "")
 	if err != nil {
 		return nil, fmt.Errorf("invalid regexp %s", params.Regexp)
 	}

--- a/pkg/validator/group.go
+++ b/pkg/validator/group.go
@@ -233,12 +233,8 @@ func newGroupNameMatchesRegexp(paramsConfig yaml.Node) (Validator, error) {
 	if err := paramsConfig.Decode(&params); err != nil {
 		return nil, err
 	}
-	r, err := compileAnchoredRegexp(params.Regexp)
-	if err != nil {
-		return nil, fmt.Errorf("invalid regexp %s: %w", params.Regexp, err)
-	}
 	return &groupNameMatchesRegexp{
-		pattern: r,
+		pattern: params.Regexp.Regexp,
 	}, nil
 }
 

--- a/pkg/validator/group.go
+++ b/pkg/validator/group.go
@@ -233,10 +233,7 @@ func newGroupNameMatchesRegexp(paramsConfig yaml.Node) (Validator, error) {
 	if err := paramsConfig.Decode(&params); err != nil {
 		return nil, err
 	}
-	if params.Regexp == "" {
-		return nil, fmt.Errorf("missing regexp")
-	}
-	r, err := regexp.Compile(params.Regexp)
+	r, err := compileAnchoredRegexpWithDefault(params.Regexp, "")
 	if err != nil {
 		return nil, fmt.Errorf("invalid regexp %s: %w", params.Regexp, err)
 	}

--- a/pkg/validator/group.go
+++ b/pkg/validator/group.go
@@ -228,12 +228,12 @@ func (h hasAllowedQueryOffset) Validate(group unmarshaler.RuleGroup, _ rulefmt.R
 
 func newGroupNameMatchesRegexp(paramsConfig yaml.Node) (Validator, error) {
 	params := struct {
-		Regexp string `yaml:"regexp"`
+		Regexp RegexpEmptyDefault `yaml:"regexp"`
 	}{}
 	if err := paramsConfig.Decode(&params); err != nil {
 		return nil, err
 	}
-	r, err := compileAnchoredRegexpWithDefault(params.Regexp, emptyRegexp)
+	r, err := compileAnchoredRegexp(params.Regexp)
 	if err != nil {
 		return nil, fmt.Errorf("invalid regexp %s: %w", params.Regexp, err)
 	}

--- a/pkg/validator/group.go
+++ b/pkg/validator/group.go
@@ -233,7 +233,7 @@ func newGroupNameMatchesRegexp(paramsConfig yaml.Node) (Validator, error) {
 	if err := paramsConfig.Decode(&params); err != nil {
 		return nil, err
 	}
-	r, err := compileAnchoredRegexpWithDefault(params.Regexp, "")
+	r, err := compileAnchoredRegexpWithDefault(params.Regexp, emptyRegexp)
 	if err != nil {
 		return nil, fmt.Errorf("invalid regexp %s: %w", params.Regexp, err)
 	}

--- a/pkg/validator/labels.go
+++ b/pkg/validator/labels.go
@@ -213,11 +213,7 @@ func newLabelMatchesRegexp(paramsConfig yaml.Node) (Validator, error) {
 	if params.Label == "" {
 		return nil, fmt.Errorf("missing label name")
 	}
-	expr, err := compileAnchoredRegexp(params.Regexp)
-	if err != nil {
-		return nil, fmt.Errorf("invalid regexp %s", params.Regexp)
-	}
-	return &labelMatchesRegexp{label: params.Label, regexp: expr}, nil
+	return &labelMatchesRegexp{label: params.Label, regexp: params.Regexp.Regexp}, nil
 }
 
 type labelMatchesRegexp struct {

--- a/pkg/validator/labels.go
+++ b/pkg/validator/labels.go
@@ -204,8 +204,8 @@ func (h labelHasAllowedValue) Validate(_ unmarshaler.RuleGroup, rule rulefmt.Rul
 
 func newLabelMatchesRegexp(paramsConfig yaml.Node) (Validator, error) {
 	params := struct {
-		Label  string `yaml:"label"`
-		Regexp string `yaml:"regexp"`
+		Label  string             `yaml:"label"`
+		Regexp RegexpEmptyDefault `yaml:"regexp"`
 	}{}
 	if err := paramsConfig.Decode(&params); err != nil {
 		return nil, err
@@ -213,7 +213,7 @@ func newLabelMatchesRegexp(paramsConfig yaml.Node) (Validator, error) {
 	if params.Label == "" {
 		return nil, fmt.Errorf("missing label name")
 	}
-	expr, err := compileAnchoredRegexpWithDefault(params.Regexp, emptyRegexp)
+	expr, err := compileAnchoredRegexp(params.Regexp)
 	if err != nil {
 		return nil, fmt.Errorf("invalid regexp %s", params.Regexp)
 	}

--- a/pkg/validator/labels.go
+++ b/pkg/validator/labels.go
@@ -213,7 +213,7 @@ func newLabelMatchesRegexp(paramsConfig yaml.Node) (Validator, error) {
 	if params.Label == "" {
 		return nil, fmt.Errorf("missing label name")
 	}
-	expr, err := regexp.Compile(params.Regexp)
+	expr, err := compileAnchoredRegexpWithDefault(params.Regexp, "")
 	if err != nil {
 		return nil, fmt.Errorf("invalid regexp %s", params.Regexp)
 	}

--- a/pkg/validator/labels.go
+++ b/pkg/validator/labels.go
@@ -213,7 +213,7 @@ func newLabelMatchesRegexp(paramsConfig yaml.Node) (Validator, error) {
 	if params.Label == "" {
 		return nil, fmt.Errorf("missing label name")
 	}
-	expr, err := compileAnchoredRegexpWithDefault(params.Regexp, "")
+	expr, err := compileAnchoredRegexpWithDefault(params.Regexp, emptyRegexp)
 	if err != nil {
 		return nil, fmt.Errorf("invalid regexp %s", params.Regexp)
 	}

--- a/pkg/validator/others.go
+++ b/pkg/validator/others.go
@@ -13,9 +13,9 @@ import (
 )
 
 type SourceTenantMetrics struct {
-	Regexp         string `yaml:"regexp"`
-	NegativeRegexp string `yaml:"negativeRegexp"`
-	Description    string `yaml:"description"`
+	Regexp         RegexpWildcardDefault `yaml:"regexp"`
+	NegativeRegexp RegexpEmptyDefault    `yaml:"negativeRegexp"`
+	Description    string                `yaml:"description"`
 }
 
 func newHasSourceTenantsForMetrics(paramsConfig yaml.Node) (Validator, error) {
@@ -33,15 +33,15 @@ func newHasSourceTenantsForMetrics(paramsConfig yaml.Node) (Validator, error) {
 	for tenant, metrics := range params.SourceTenants {
 		m := make([]tenantMetrics, len(metrics))
 		for i, metric := range metrics {
-			compiledRegexp, err := compileAnchoredRegexpWithDefault(metric.Regexp, matchAnythingRegexp)
+			compiledRegexp, err := compileAnchoredRegexp(metric.Regexp)
 			if err != nil {
-				return nil, fmt.Errorf("invalid metric name regexp: %s", anchorRegexp(metric.Regexp))
+				return nil, fmt.Errorf("invalid metric name regexp: %s", anchorRegexp(metric.Regexp.String()))
 			}
 			compiledNegativeRegexp := (*regexp.Regexp)(nil)
 			if metric.NegativeRegexp != "" {
-				compiledNegativeRegexp, err = compileAnchoredRegexpWithDefault(metric.NegativeRegexp, emptyRegexp)
+				compiledNegativeRegexp, err = compileAnchoredRegexp(metric.NegativeRegexp)
 				if err != nil {
-					return nil, fmt.Errorf("invalid metric name regexp: %s", anchorRegexp(metric.NegativeRegexp))
+					return nil, fmt.Errorf("invalid metric name regexp: %s", anchorRegexp(metric.NegativeRegexp.String()))
 				}
 			}
 			m[i] = tenantMetrics{

--- a/pkg/validator/others.go
+++ b/pkg/validator/others.go
@@ -33,7 +33,7 @@ func newHasSourceTenantsForMetrics(paramsConfig yaml.Node) (Validator, error) {
 	for tenant, metrics := range params.SourceTenants {
 		m := make([]tenantMetrics, len(metrics))
 		for i, metric := range metrics {
-			compiledRegexp, err := compileAnchoredRegexpWithDefault(metric.Regexp, ".*")
+			compiledRegexp, err := compileAnchoredRegexpWithDefault(metric.Regexp, matchAnythingRegexp)
 			if err != nil {
 				return nil, fmt.Errorf("invalid metric name regexp: %s", anchorRegexp(metric.Regexp))
 			}

--- a/pkg/validator/others.go
+++ b/pkg/validator/others.go
@@ -33,20 +33,9 @@ func newHasSourceTenantsForMetrics(paramsConfig yaml.Node) (Validator, error) {
 	for tenant, metrics := range params.SourceTenants {
 		m := make([]tenantMetrics, len(metrics))
 		for i, metric := range metrics {
-			compiledRegexp, err := compileAnchoredRegexp(metric.Regexp)
-			if err != nil {
-				return nil, fmt.Errorf("invalid metric name regexp: %s", anchorRegexp(metric.Regexp.String()))
-			}
-			compiledNegativeRegexp := (*regexp.Regexp)(nil)
-			if metric.NegativeRegexp != "" {
-				compiledNegativeRegexp, err = compileAnchoredRegexp(metric.NegativeRegexp)
-				if err != nil {
-					return nil, fmt.Errorf("invalid metric name regexp: %s", anchorRegexp(metric.NegativeRegexp.String()))
-				}
-			}
 			m[i] = tenantMetrics{
-				regexp:         compiledRegexp,
-				negativeRegexp: compiledNegativeRegexp,
+				regexp:         metric.Regexp.Regexp,
+				negativeRegexp: metric.NegativeRegexp.Regexp,
 				description:    metric.Description,
 			}
 		}

--- a/pkg/validator/others.go
+++ b/pkg/validator/others.go
@@ -33,13 +33,13 @@ func newHasSourceTenantsForMetrics(paramsConfig yaml.Node) (Validator, error) {
 	for tenant, metrics := range params.SourceTenants {
 		m := make([]tenantMetrics, len(metrics))
 		for i, metric := range metrics {
-			compiledRegexp, err := compileAnchoredRegexp(metric.Regexp)
+			compiledRegexp, err := compileAnchoredRegexpWithDefault(metric.Regexp, ".*")
 			if err != nil {
 				return nil, fmt.Errorf("invalid metric name regexp: %s", anchorRegexp(metric.Regexp))
 			}
 			compiledNegativeRegexp := (*regexp.Regexp)(nil)
 			if metric.NegativeRegexp != "" {
-				compiledNegativeRegexp, err = compileAnchoredRegexp(metric.NegativeRegexp)
+				compiledNegativeRegexp, err = compileAnchoredRegexpWithDefault(metric.NegativeRegexp, "")
 				if err != nil {
 					return nil, fmt.Errorf("invalid metric name regexp: %s", anchorRegexp(metric.NegativeRegexp))
 				}

--- a/pkg/validator/others.go
+++ b/pkg/validator/others.go
@@ -39,7 +39,7 @@ func newHasSourceTenantsForMetrics(paramsConfig yaml.Node) (Validator, error) {
 			}
 			compiledNegativeRegexp := (*regexp.Regexp)(nil)
 			if metric.NegativeRegexp != "" {
-				compiledNegativeRegexp, err = compileAnchoredRegexpWithDefault(metric.NegativeRegexp, "")
+				compiledNegativeRegexp, err = compileAnchoredRegexpWithDefault(metric.NegativeRegexp, emptyRegexp)
 				if err != nil {
 					return nil, fmt.Errorf("invalid metric name regexp: %s", anchorRegexp(metric.NegativeRegexp))
 				}

--- a/pkg/validator/promql_expression.go
+++ b/pkg/validator/promql_expression.go
@@ -130,8 +130,8 @@ type expressionUsesOnlyAllowedLabelsForMetricRegexp struct {
 
 func newExpressionUsesOnlyAllowedLabelsForMetricRegexp(paramsConfig yaml.Node) (Validator, error) {
 	params := struct {
-		AllowedLabels    []string `yaml:"allowedLabels"`
-		MetricNameRegexp string   `yaml:"metricNameRegexp"`
+		AllowedLabels    []string              `yaml:"allowedLabels"`
+		MetricNameRegexp RegexpWildcardDefault `yaml:"metricNameRegexp"`
 	}{}
 	if err := paramsConfig.Decode(&params); err != nil {
 		return nil, err
@@ -139,7 +139,7 @@ func newExpressionUsesOnlyAllowedLabelsForMetricRegexp(paramsConfig yaml.Node) (
 	if len(params.AllowedLabels) == 0 {
 		return nil, fmt.Errorf("missing labels")
 	}
-	compiled, err := compileAnchoredRegexpWithDefault(params.MetricNameRegexp, matchAnythingRegexp)
+	compiled, err := compileAnchoredRegexp(params.MetricNameRegexp)
 	if err != nil {
 		return nil, fmt.Errorf("invalid metric name regexp %s: %w", params.MetricNameRegexp, err)
 	}
@@ -178,8 +178,8 @@ type expressionUsesOnlyAllowedLabelValuesForMetricRegexp struct {
 
 func newExpressionUsesOnlyAllowedLabelValuesForMetricRegexp(paramsConfig yaml.Node) (Validator, error) {
 	params := struct {
-		AllowedLabelValues map[string][]string `yaml:"allowedLabelValues"`
-		MetricNameRegexp   string              `yaml:"metricNameRegexp"`
+		AllowedLabelValues map[string][]string   `yaml:"allowedLabelValues"`
+		MetricNameRegexp   RegexpWildcardDefault `yaml:"metricNameRegexp"`
 	}{}
 	if err := paramsConfig.Decode(&params); err != nil {
 		return nil, err
@@ -187,7 +187,7 @@ func newExpressionUsesOnlyAllowedLabelValuesForMetricRegexp(paramsConfig yaml.No
 	if len(params.AllowedLabelValues) == 0 {
 		return nil, fmt.Errorf("missing allowed label values")
 	}
-	compiled, err := compileAnchoredRegexpWithDefault(params.MetricNameRegexp, matchAnythingRegexp)
+	compiled, err := compileAnchoredRegexp(params.MetricNameRegexp)
 	if err != nil {
 		return nil, fmt.Errorf("invalid metric name regexp %s: %w", params.MetricNameRegexp, err)
 	}
@@ -241,8 +241,8 @@ type expressionDoesNotUseLabelsForMetricRegexp struct {
 
 func newExpressionDoesNotUseLabelsForMetricRegexp(paramsConfig yaml.Node) (Validator, error) {
 	params := struct {
-		Labels           []string `yaml:"labels"`
-		MetricNameRegexp string   `yaml:"metricNameRegexp"`
+		Labels           []string              `yaml:"labels"`
+		MetricNameRegexp RegexpWildcardDefault `yaml:"metricNameRegexp"`
 	}{}
 	if err := paramsConfig.Decode(&params); err != nil {
 		return nil, err
@@ -250,7 +250,7 @@ func newExpressionDoesNotUseLabelsForMetricRegexp(paramsConfig yaml.Node) (Valid
 	if len(params.Labels) == 0 {
 		return nil, fmt.Errorf("missing labels")
 	}
-	compiled, err := compileAnchoredRegexpWithDefault(params.MetricNameRegexp, matchAnythingRegexp)
+	compiled, err := compileAnchoredRegexp(params.MetricNameRegexp)
 	if err != nil {
 		return nil, fmt.Errorf("invalid metric name regexp %s: %w", params.MetricNameRegexp, err)
 	}
@@ -608,14 +608,14 @@ func (e expressionWithNoMetricName) Validate(_ unmarshaler.RuleGroup, rule rulef
 
 func newExpressionDoesNotUseMetrics(paramsConfig yaml.Node) (Validator, error) {
 	params := struct {
-		MetricNameRegexps []string `yaml:"metricNameRegexps"`
+		MetricNameRegexps []RegexpEmptyDefault `yaml:"metricNameRegexps"`
 	}{}
 	if err := paramsConfig.Decode(&params); err != nil {
 		return nil, err
 	}
 	v := expressionDoesNotUseMetrics{}
 	for _, r := range params.MetricNameRegexps {
-		compiled, err := compileAnchoredRegexpWithDefault(r, emptyRegexp)
+		compiled, err := compileAnchoredRegexp(r)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/validator/promql_expression.go
+++ b/pkg/validator/promql_expression.go
@@ -139,7 +139,7 @@ func newExpressionUsesOnlyAllowedLabelsForMetricRegexp(paramsConfig yaml.Node) (
 	if len(params.AllowedLabels) == 0 {
 		return nil, fmt.Errorf("missing labels")
 	}
-	compiled, err := compileAnchoredRegexpWithDefault(params.MetricNameRegexp, ".*")
+	compiled, err := compileAnchoredRegexpWithDefault(params.MetricNameRegexp, matchAnythingRegexp)
 	if err != nil {
 		return nil, fmt.Errorf("invalid metric name regexp %s: %w", params.MetricNameRegexp, err)
 	}
@@ -187,7 +187,7 @@ func newExpressionUsesOnlyAllowedLabelValuesForMetricRegexp(paramsConfig yaml.No
 	if len(params.AllowedLabelValues) == 0 {
 		return nil, fmt.Errorf("missing allowed label values")
 	}
-	compiled, err := compileAnchoredRegexpWithDefault(params.MetricNameRegexp, ".*")
+	compiled, err := compileAnchoredRegexpWithDefault(params.MetricNameRegexp, matchAnythingRegexp)
 	if err != nil {
 		return nil, fmt.Errorf("invalid metric name regexp %s: %w", params.MetricNameRegexp, err)
 	}
@@ -250,7 +250,7 @@ func newExpressionDoesNotUseLabelsForMetricRegexp(paramsConfig yaml.Node) (Valid
 	if len(params.Labels) == 0 {
 		return nil, fmt.Errorf("missing labels")
 	}
-	compiled, err := compileAnchoredRegexpWithDefault(params.MetricNameRegexp, ".*")
+	compiled, err := compileAnchoredRegexpWithDefault(params.MetricNameRegexp, matchAnythingRegexp)
 	if err != nil {
 		return nil, fmt.Errorf("invalid metric name regexp %s: %w", params.MetricNameRegexp, err)
 	}

--- a/pkg/validator/promql_expression.go
+++ b/pkg/validator/promql_expression.go
@@ -615,7 +615,7 @@ func newExpressionDoesNotUseMetrics(paramsConfig yaml.Node) (Validator, error) {
 	}
 	v := expressionDoesNotUseMetrics{}
 	for _, r := range params.MetricNameRegexps {
-		compiled, err := compileAnchoredRegexpWithDefault(r, "")
+		compiled, err := compileAnchoredRegexpWithDefault(r, emptyRegexp)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/validator/promql_expression.go
+++ b/pkg/validator/promql_expression.go
@@ -139,14 +139,10 @@ func newExpressionUsesOnlyAllowedLabelsForMetricRegexp(paramsConfig yaml.Node) (
 	if len(params.AllowedLabels) == 0 {
 		return nil, fmt.Errorf("missing labels")
 	}
-	compiled, err := compileAnchoredRegexp(params.MetricNameRegexp)
-	if err != nil {
-		return nil, fmt.Errorf("invalid metric name regexp %s: %w", params.MetricNameRegexp, err)
-	}
 	allowedLabels := labelsMap(params.AllowedLabels)
 	// Metric name label is implicitly allowed
 	allowedLabels[metricNameLabel] = struct{}{}
-	return &expressionUsesOnlyAllowedLabelsForMetricRegexp{allowedLabels: allowedLabels, metricNameRegexp: compiled}, nil
+	return &expressionUsesOnlyAllowedLabelsForMetricRegexp{allowedLabels: allowedLabels, metricNameRegexp: params.MetricNameRegexp.Regexp}, nil
 }
 
 func (h expressionUsesOnlyAllowedLabelsForMetricRegexp) String() string {
@@ -187,11 +183,7 @@ func newExpressionUsesOnlyAllowedLabelValuesForMetricRegexp(paramsConfig yaml.No
 	if len(params.AllowedLabelValues) == 0 {
 		return nil, fmt.Errorf("missing allowed label values")
 	}
-	compiled, err := compileAnchoredRegexp(params.MetricNameRegexp)
-	if err != nil {
-		return nil, fmt.Errorf("invalid metric name regexp %s: %w", params.MetricNameRegexp, err)
-	}
-	return &expressionUsesOnlyAllowedLabelValuesForMetricRegexp{allowedLabelValues: params.AllowedLabelValues, metricNameRegexp: compiled}, nil
+	return &expressionUsesOnlyAllowedLabelValuesForMetricRegexp{allowedLabelValues: params.AllowedLabelValues, metricNameRegexp: params.MetricNameRegexp.Regexp}, nil
 }
 
 func (h expressionUsesOnlyAllowedLabelValuesForMetricRegexp) String() string {
@@ -250,11 +242,7 @@ func newExpressionDoesNotUseLabelsForMetricRegexp(paramsConfig yaml.Node) (Valid
 	if len(params.Labels) == 0 {
 		return nil, fmt.Errorf("missing labels")
 	}
-	compiled, err := compileAnchoredRegexp(params.MetricNameRegexp)
-	if err != nil {
-		return nil, fmt.Errorf("invalid metric name regexp %s: %w", params.MetricNameRegexp, err)
-	}
-	return &expressionDoesNotUseLabelsForMetricRegexp{labels: labelsMap(params.Labels), metricNameRegexp: compiled}, nil
+	return &expressionDoesNotUseLabelsForMetricRegexp{labels: labelsMap(params.Labels), metricNameRegexp: params.MetricNameRegexp.Regexp}, nil
 }
 
 func (h expressionDoesNotUseLabelsForMetricRegexp) String() string {
@@ -615,11 +603,7 @@ func newExpressionDoesNotUseMetrics(paramsConfig yaml.Node) (Validator, error) {
 	}
 	v := expressionDoesNotUseMetrics{}
 	for _, r := range params.MetricNameRegexps {
-		compiled, err := compileAnchoredRegexp(r)
-		if err != nil {
-			return nil, err
-		}
-		v.metricNameRegexps = append(v.metricNameRegexps, compiled)
+		v.metricNameRegexps = append(v.metricNameRegexps, r.Regexp)
 	}
 	return &v, nil
 }

--- a/pkg/validator/promql_expression.go
+++ b/pkg/validator/promql_expression.go
@@ -139,7 +139,7 @@ func newExpressionUsesOnlyAllowedLabelsForMetricRegexp(paramsConfig yaml.Node) (
 	if len(params.AllowedLabels) == 0 {
 		return nil, fmt.Errorf("missing labels")
 	}
-	compiled, err := compileAnchoredRegexp(params.MetricNameRegexp)
+	compiled, err := compileAnchoredRegexpWithDefault(params.MetricNameRegexp, ".*")
 	if err != nil {
 		return nil, fmt.Errorf("invalid metric name regexp %s: %w", params.MetricNameRegexp, err)
 	}
@@ -187,11 +187,7 @@ func newExpressionUsesOnlyAllowedLabelValuesForMetricRegexp(paramsConfig yaml.No
 	if len(params.AllowedLabelValues) == 0 {
 		return nil, fmt.Errorf("missing allowed label values")
 	}
-	if params.MetricNameRegexp == "" {
-		// default to matching anything
-		params.MetricNameRegexp = ".*"
-	}
-	compiled, err := compileAnchoredRegexp(params.MetricNameRegexp)
+	compiled, err := compileAnchoredRegexpWithDefault(params.MetricNameRegexp, ".*")
 	if err != nil {
 		return nil, fmt.Errorf("invalid metric name regexp %s: %w", params.MetricNameRegexp, err)
 	}
@@ -254,7 +250,7 @@ func newExpressionDoesNotUseLabelsForMetricRegexp(paramsConfig yaml.Node) (Valid
 	if len(params.Labels) == 0 {
 		return nil, fmt.Errorf("missing labels")
 	}
-	compiled, err := compileAnchoredRegexp(params.MetricNameRegexp)
+	compiled, err := compileAnchoredRegexpWithDefault(params.MetricNameRegexp, ".*")
 	if err != nil {
 		return nil, fmt.Errorf("invalid metric name regexp %s: %w", params.MetricNameRegexp, err)
 	}
@@ -619,7 +615,7 @@ func newExpressionDoesNotUseMetrics(paramsConfig yaml.Node) (Validator, error) {
 	}
 	v := expressionDoesNotUseMetrics{}
 	for _, r := range params.MetricNameRegexps {
-		compiled, err := compileAnchoredRegexp(r)
+		compiled, err := compileAnchoredRegexpWithDefault(r, "")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/validator/promql_expression_helpers.go
+++ b/pkg/validator/promql_expression_helpers.go
@@ -156,7 +156,7 @@ func getExpressionUsedLabelsForMetric(expr string, metricRegexp *regexp.Regexp) 
 }
 
 func getExpressionUsedLabels(expr string) ([]string, error) {
-	return getExpressionUsedLabelsForMetric(expr, regexp.MustCompile(".*"))
+	return getExpressionUsedLabelsForMetric(expr, regexp.MustCompile(matchAnythingRegexp))
 }
 
 func getExpressionVectorSelectors(expr string) ([]*parser.VectorSelector, error) {

--- a/pkg/validator/promql_expression_helpers.go
+++ b/pkg/validator/promql_expression_helpers.go
@@ -156,7 +156,7 @@ func getExpressionUsedLabelsForMetric(expr string, metricRegexp *regexp.Regexp) 
 }
 
 func getExpressionUsedLabels(expr string) ([]string, error) {
-	return getExpressionUsedLabelsForMetric(expr, regexp.MustCompile(matchAnythingRegexp))
+	return getExpressionUsedLabelsForMetric(expr, regexp.MustCompile(".*"))
 }
 
 func getExpressionVectorSelectors(expr string) ([]*parser.VectorSelector, error) {

--- a/pkg/validator/promql_expression_helpers_test.go
+++ b/pkg/validator/promql_expression_helpers_test.go
@@ -102,7 +102,7 @@ func TestGetLabelMatchersForMetricRegexp(t *testing.T) {
 		{expr: "up{bar='foo'}", metricRegexp: "up", expected: []*labels.Matcher{
 			MustNewMatcher(labels.MatchEqual, "__name__", "up"), MustNewMatcher(labels.MatchEqual, "bar", "foo"),
 		}, expectedErr: nil},
-		{expr: "up{bar!='foo'}", metricRegexp: ".*", expected: []*labels.Matcher{
+		{expr: "up{bar!='foo'}", metricRegexp: matchAnythingRegexp, expected: []*labels.Matcher{
 			MustNewMatcher(labels.MatchEqual, "__name__", "up"), MustNewMatcher(labels.MatchNotEqual, "bar", "foo"),
 		}, expectedErr: nil},
 		{expr: "up{bar='foo', bar2!~'foo'}", metricRegexp: "up", expected: []*labels.Matcher{

--- a/pkg/validator/recording_rule.go
+++ b/pkg/validator/recording_rule.go
@@ -12,20 +12,13 @@ import (
 
 func newRecordedMetricNameMatchesRegexp(paramsConfig yaml.Node) (Validator, error) {
 	params := struct {
-		Regexp RegexpEmptyDefault `yaml:"regexp"`
+		Regexp RegexpForbidEmpty `yaml:"regexp"`
 	}{}
 	if err := paramsConfig.Decode(&params); err != nil {
 		return nil, err
 	}
-	if params.Regexp == "" {
-		return nil, fmt.Errorf("missing regexp")
-	}
-	r, err := compileAnchoredRegexp(params.Regexp)
-	if err != nil {
-		return nil, fmt.Errorf("invalid regexp %s: %w", params.Regexp, err)
-	}
 	return &recordedMetricNameMatchesRegexp{
-		pattern: r,
+		pattern: params.Regexp.Regexp,
 	}, nil
 }
 
@@ -47,20 +40,13 @@ func (h recordedMetricNameMatchesRegexp) Validate(_ unmarshaler.RuleGroup, rule 
 
 func newRecordedMetricNameDoesNotMatchRegexp(paramsConfig yaml.Node) (Validator, error) {
 	params := struct {
-		Regexp RegexpEmptyDefault `yaml:"regexp"`
+		Regexp RegexpForbidEmpty `yaml:"regexp"`
 	}{}
 	if err := paramsConfig.Decode(&params); err != nil {
 		return nil, err
 	}
-	if params.Regexp == "" {
-		return nil, fmt.Errorf("missing regexp")
-	}
-	r, err := compileAnchoredRegexp(params.Regexp)
-	if err != nil {
-		return nil, fmt.Errorf("invalid regexp %s: %w", params.Regexp, err)
-	}
 	return &recordedMetricNameDoesNotMatchRegexp{
-		pattern: r,
+		pattern: params.Regexp.Regexp,
 	}, nil
 }
 

--- a/pkg/validator/recording_rule.go
+++ b/pkg/validator/recording_rule.go
@@ -20,7 +20,7 @@ func newRecordedMetricNameMatchesRegexp(paramsConfig yaml.Node) (Validator, erro
 	if params.Regexp == "" {
 		return nil, fmt.Errorf("missing regexp")
 	}
-	r, err := regexp.Compile(params.Regexp)
+	r, err := compileAnchoredRegexpWithDefault(params.Regexp, "")
 	if err != nil {
 		return nil, fmt.Errorf("invalid regexp %s: %w", params.Regexp, err)
 	}
@@ -55,7 +55,7 @@ func newRecordedMetricNameDoesNotMatchRegexp(paramsConfig yaml.Node) (Validator,
 	if params.Regexp == "" {
 		return nil, fmt.Errorf("missing regexp")
 	}
-	r, err := regexp.Compile(params.Regexp)
+	r, err := compileAnchoredRegexpWithDefault(params.Regexp, "")
 	if err != nil {
 		return nil, fmt.Errorf("invalid regexp %s: %w", params.Regexp, err)
 	}

--- a/pkg/validator/recording_rule.go
+++ b/pkg/validator/recording_rule.go
@@ -20,7 +20,7 @@ func newRecordedMetricNameMatchesRegexp(paramsConfig yaml.Node) (Validator, erro
 	if params.Regexp == "" {
 		return nil, fmt.Errorf("missing regexp")
 	}
-	r, err := compileAnchoredRegexpWithDefault(params.Regexp, "")
+	r, err := compileAnchoredRegexpWithDefault(params.Regexp, emptyRegexp)
 	if err != nil {
 		return nil, fmt.Errorf("invalid regexp %s: %w", params.Regexp, err)
 	}
@@ -55,7 +55,7 @@ func newRecordedMetricNameDoesNotMatchRegexp(paramsConfig yaml.Node) (Validator,
 	if params.Regexp == "" {
 		return nil, fmt.Errorf("missing regexp")
 	}
-	r, err := compileAnchoredRegexpWithDefault(params.Regexp, "")
+	r, err := compileAnchoredRegexpWithDefault(params.Regexp, emptyRegexp)
 	if err != nil {
 		return nil, fmt.Errorf("invalid regexp %s: %w", params.Regexp, err)
 	}

--- a/pkg/validator/recording_rule.go
+++ b/pkg/validator/recording_rule.go
@@ -12,7 +12,7 @@ import (
 
 func newRecordedMetricNameMatchesRegexp(paramsConfig yaml.Node) (Validator, error) {
 	params := struct {
-		Regexp string `yaml:"regexp"`
+		Regexp RegexpEmptyDefault `yaml:"regexp"`
 	}{}
 	if err := paramsConfig.Decode(&params); err != nil {
 		return nil, err
@@ -20,7 +20,7 @@ func newRecordedMetricNameMatchesRegexp(paramsConfig yaml.Node) (Validator, erro
 	if params.Regexp == "" {
 		return nil, fmt.Errorf("missing regexp")
 	}
-	r, err := compileAnchoredRegexpWithDefault(params.Regexp, emptyRegexp)
+	r, err := compileAnchoredRegexp(params.Regexp)
 	if err != nil {
 		return nil, fmt.Errorf("invalid regexp %s: %w", params.Regexp, err)
 	}
@@ -47,7 +47,7 @@ func (h recordedMetricNameMatchesRegexp) Validate(_ unmarshaler.RuleGroup, rule 
 
 func newRecordedMetricNameDoesNotMatchRegexp(paramsConfig yaml.Node) (Validator, error) {
 	params := struct {
-		Regexp string `yaml:"regexp"`
+		Regexp RegexpEmptyDefault `yaml:"regexp"`
 	}{}
 	if err := paramsConfig.Decode(&params); err != nil {
 		return nil, err
@@ -55,7 +55,7 @@ func newRecordedMetricNameDoesNotMatchRegexp(paramsConfig yaml.Node) (Validator,
 	if params.Regexp == "" {
 		return nil, fmt.Errorf("missing regexp")
 	}
-	r, err := compileAnchoredRegexpWithDefault(params.Regexp, emptyRegexp)
+	r, err := compileAnchoredRegexp(params.Regexp)
 	if err != nil {
 		return nil, fmt.Errorf("invalid regexp %s: %w", params.Regexp, err)
 	}

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -14,6 +14,11 @@ type Validator interface {
 	Validate(group unmarshaler.RuleGroup, rule rulefmt.Rule, prometheusClient *prometheus.Client) []error
 }
 
+const (
+	matchAnythingRegexp = ".*"
+	emptyRegexp         = ""
+)
+
 func anchorRegexp(regexpString string) string {
 	return fmt.Sprintf("^%s$", regexpString)
 }

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -18,6 +18,13 @@ func anchorRegexp(regexpString string) string {
 	return fmt.Sprintf("^%s$", regexpString)
 }
 
-func compileAnchoredRegexp(regexpString string) (*regexp.Regexp, error) {
+func compileAnchoredRegexpWithDefault(regexpString, defaultValue string) (*regexp.Regexp, error) {
+	if regexpString == "" {
+		return regexp.Compile(anchorRegexp(defaultValue))
+	}
 	return regexp.Compile(anchorRegexp(regexpString))
+}
+
+func compileAnchoredRegexp(regexpString string) (*regexp.Regexp, error) {
+	return compileAnchoredRegexpWithDefault(regexpString, "")
 }

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -59,13 +59,13 @@ var testCases = []struct {
 	{name: "ruleDoesNotHaveAnyOfExpectedAnnotations", validator: hasAnyOfAnnotations{annotations: []string{"foo", "foo2"}}, rule: rulefmt.Rule{Annotations: map[string]string{"xxx": "yyy"}}, expectedErrors: 1},
 
 	// labelMatchesRegexp
-	{name: "ruleLabelMatchesRegexp", validator: labelMatchesRegexp{label: "foo", regexp: regexp.MustCompile(".*")}, rule: rulefmt.Rule{Labels: map[string]string{"foo": "bar"}}, expectedErrors: 0},
-	{name: "ruleLabelMissingRegexValidatedLabel", validator: labelMatchesRegexp{label: "foo", regexp: regexp.MustCompile(".*")}, rule: rulefmt.Rule{}, expectedErrors: 0},
+	{name: "ruleLabelMatchesRegexp", validator: labelMatchesRegexp{label: "foo", regexp: regexp.MustCompile(matchAnythingRegexp)}, rule: rulefmt.Rule{Labels: map[string]string{"foo": "bar"}}, expectedErrors: 0},
+	{name: "ruleLabelMissingRegexValidatedLabel", validator: labelMatchesRegexp{label: "foo", regexp: regexp.MustCompile(matchAnythingRegexp)}, rule: rulefmt.Rule{}, expectedErrors: 0},
 	{name: "ruleLabelDoesNotMatchRegexp", validator: labelMatchesRegexp{label: "foo", regexp: regexp.MustCompile(`\d+`)}, rule: rulefmt.Rule{Labels: map[string]string{"foo": "bar"}}, expectedErrors: 1},
 
 	// annotationMatchesRegexp
-	{name: "ruleAnnotationMatchesRegexp", validator: annotationMatchesRegexp{annotation: "foo", regexp: regexp.MustCompile(".*")}, rule: rulefmt.Rule{Annotations: map[string]string{"foo": "bar"}}, expectedErrors: 0},
-	{name: "ruleAnnotationMissingRegexValidatedLabel", validator: annotationMatchesRegexp{annotation: "foo", regexp: regexp.MustCompile(".*")}, rule: rulefmt.Rule{}, expectedErrors: 0},
+	{name: "ruleAnnotationMatchesRegexp", validator: annotationMatchesRegexp{annotation: "foo", regexp: regexp.MustCompile(matchAnythingRegexp)}, rule: rulefmt.Rule{Annotations: map[string]string{"foo": "bar"}}, expectedErrors: 0},
+	{name: "ruleAnnotationMissingRegexValidatedLabel", validator: annotationMatchesRegexp{annotation: "foo", regexp: regexp.MustCompile(matchAnythingRegexp)}, rule: rulefmt.Rule{}, expectedErrors: 0},
 	{name: "ruleAnnotationDoesNotMatchRegexp", validator: annotationMatchesRegexp{annotation: "foo", regexp: regexp.MustCompile(`\d+`)}, rule: rulefmt.Rule{Annotations: map[string]string{"foo": "bar"}}, expectedErrors: 1},
 
 	// labelHasAllowedValue

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func mustCompileAnchoredRegexp(regexpString string) *regexp.Regexp {
-	compiled, err := compileAnchoredRegexp(RegexpEmptyDefault(regexpString))
+	compiled, err := compileAnchoredRegexp(regexpString)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func mustCompileAnchoredRegexp(regexpString string) *regexp.Regexp {
-	compiled, err := compileAnchoredRegexp(regexpString)
+	compiled, err := compileAnchoredRegexp(RegexpEmptyDefault(regexpString))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
- all regexps now default to .*, except for negative regexps which explicitly default to ""