### PR TITLE
feat: Add hasLabelsForEveryAggregation validator

### DIFF
--- a/pkg/validator/config.go
+++ b/pkg/validator/config.go
@@ -14,6 +14,7 @@ type validatorCreator func(params yaml.Node) (Validator, error)
 var registeredUniversalRuleValidators = map[string]validatorCreator{
 	// Labels
 	"hasLabels":            newHasLabels,
+	"hasLabelsForEveryAggregation": newHasLabelsForEveryAggregation,
 	"doesNotHaveLabels":    newDoesNotHaveLabels,
 	"hasAnyOfLabels":       newHasAnyOfLabels,
 	"labelMatchesRegexp":   newLabelMatchesRegexp,


### PR DESCRIPTION
This adds a `hasLabelsForEveryAggregation` validator, which verifies that every aggregation in an alert expression has a set of labels. The new validator has a `excludeRuleLabels` option, which ignores labels in `labels` if they are specified in the alert rule's labels.

This is useful for partially ensuring that alert rules return labels that are required for `AlertmanagerConfig` matchers. For example, when using `prometheus-operator`, the operator adds an implicit `namespace` matcher to every `AlertmanagerConfig`. Alert rules that don't return the `namespace` label get silently blackhole'd. Because of this, aggregations are a huge source of blackhole'd alerts for us.